### PR TITLE
fix(ansible): idempotency, become_user, no_log, and tarball cleanup safety

### DIFF
--- a/roles/credentials.vault/tasks/02_render_vault_cleartext.yml
+++ b/roles/credentials.vault/tasks/02_render_vault_cleartext.yml
@@ -13,3 +13,4 @@
     src: default_vault.yml.j2
     dest: "{{ vault_output_dir }}/default_vault.yml"
     mode: "0600"
+  no_log: true

--- a/roles/deployer.bootstrap/tasks/03_shell.yml
+++ b/roles/deployer.bootstrap/tasks/03_shell.yml
@@ -10,6 +10,8 @@
     repo: https://github.com/ohmyzsh/ohmyzsh.git
     dest: "/home/{{ DEPLOYER_CLI_USER }}/.oh-my-zsh"
     update: false
+  become: true
+  become_user: "{{ DEPLOYER_CLI_USER }}"
 
 - name: DEPLOYER BOOTSTRAP - CHECK ZSH BINARY EXISTS
   ansible.builtin.stat:

--- a/roles/proxmox.init/tasks/02_fix_remote_locale.yml
+++ b/roles/proxmox.init/tasks/02_fix_remote_locale.yml
@@ -14,15 +14,10 @@
       echo \"LC_ALL={{ proxmox_locale }}\" >> /etc/default/locale
       echo \"LANGUAGE={{ proxmox_locale }}\" >> /etc/default/locale
     "'
+  changed_when: true
 
 - name: PROXMOX INIT - RUN LOCALE-GEN {{ proxmox_locale }}
   ansible.builtin.shell: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "locale-gen {{ proxmox_locale }} 2>/dev/null || true"
   changed_when: true
-
-- name: PROXMOX INIT - EXPORT LOCALE IN REMOTE SESSION
-  ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
-    "export LANG={{ proxmox_locale }} LC_ALL={{ proxmox_locale }} LANGUAGE={{ proxmox_locale }}"
-  changed_when: false

--- a/roles/proxmox.init/tasks/03_create_network_bridge.yml
+++ b/roles/proxmox.init/tasks/03_create_network_bridge.yml
@@ -28,6 +28,7 @@
   when: item.name not in existing_bridges.stdout
   loop: "{{ range42_lab_bridges }}"
   register: bridges_created
+  changed_when: item.name not in existing_bridges.stdout
 
 - name: PROXMOX INIT - APPLY NETWORK CONFIGURATION
   ansible.builtin.shell: >
@@ -42,6 +43,7 @@
     scp {{ role_path }}/files/inject_nat_rules.sh
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:/tmp/inject_nat_rules.sh &&
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} "chmod +x /tmp/inject_nat_rules.sh"
+  changed_when: true
 
 - name: PROXMOX INIT - RENDER NAT RULES FOR ENABLED BRIDGES
   ansible.builtin.template:
@@ -59,12 +61,14 @@
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "/tmp/inject_nat_rules.sh {{ item.name }} /tmp/range42_nat_{{ item.name }}.txt"
   loop: "{{ range42_lab_bridges | selectattr('nat') | list }}"
+  changed_when: true
 
 - name: PROXMOX INIT - REMOVE NAT (DISABLED BRIDGES)
   ansible.builtin.shell: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "/tmp/inject_nat_rules.sh {{ item.name }} REMOVE"
   loop: "{{ range42_lab_bridges | rejectattr('nat') | list }}"
+  changed_when: true
 
 - name: PROXMOX INIT - CLEAN UP LOCAL NAT TEMP FILES
   ansible.builtin.file:
@@ -76,6 +80,7 @@
   ansible.builtin.shell: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "rm -f /tmp/inject_nat_rules.sh"
+  changed_when: true
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 

--- a/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
+++ b/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
@@ -29,3 +29,4 @@
     "echo '{{ jump_user }}:{{ jump_password }}' | chpasswd"
   when: jump_on_proxmox | default('YES') | upper == 'YES'
   no_log: true
+  changed_when: true

--- a/roles/workspace.credentials/tasks/02_deploy_secrets.yml
+++ b/roles/workspace.credentials/tasks/02_deploy_secrets.yml
@@ -6,46 +6,51 @@
 #
 # source: configure.deployer-cli/tasks/07_03_deploy_secrets_tarball.yml
 
-- name: WORKSPACE CREDENTIALS - CREATE SECRETS TARBALL ON LOCALHOST
-  ansible.builtin.archive:
-    path: "{{ INFRASTRUCTURE__AUTO_GENERATED__CONFIG_DIR_LOCAL }}/secrets/"
-    dest: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-  delegate_to: localhost
-  become: false
+- name: WORKSPACE CREDENTIALS - DEPLOY SECRETS
+  block:
+    - name: WORKSPACE CREDENTIALS - CREATE SECRETS TARBALL ON LOCALHOST
+      ansible.builtin.archive:
+        path: "{{ INFRASTRUCTURE__AUTO_GENERATED__CONFIG_DIR_LOCAL }}/secrets/"
+        dest: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+      delegate_to: localhost
+      become: false
 
-- name: WORKSPACE CREDENTIALS - UPLOAD SECRETS TARBALL TO DEPLOYER-CLI
-  ansible.builtin.copy:
-    src: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-    dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-    owner: "{{ DEPLOYER_CLI_USER }}"
-    group: "{{ DEPLOYER_CLI_USER }}"
-    mode: "0600"
+    - name: WORKSPACE CREDENTIALS - UPLOAD SECRETS TARBALL TO DEPLOYER-CLI
+      ansible.builtin.copy:
+        src: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+        dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+        owner: "{{ DEPLOYER_CLI_USER }}"
+        group: "{{ DEPLOYER_CLI_USER }}"
+        mode: "0600"
 
-- name: WORKSPACE CREDENTIALS - EXTRACT SECRETS TARBALL
-  ansible.builtin.unarchive:
-    src: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-    dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets/"
-    owner: "{{ DEPLOYER_CLI_USER }}"
-    group: "{{ DEPLOYER_CLI_USER }}"
-    remote_src: true
+    - name: WORKSPACE CREDENTIALS - EXTRACT SECRETS TARBALL
+      ansible.builtin.unarchive:
+        src: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+        dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets/"
+        owner: "{{ DEPLOYER_CLI_USER }}"
+        group: "{{ DEPLOYER_CLI_USER }}"
+        remote_src: true
 
-- name: WORKSPACE CREDENTIALS - DEPLOY VAULT UTILITY SCRIPTS
-  ansible.builtin.copy:
-    src: "secrets-utils/"
-    dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets/"
-    owner: "{{ DEPLOYER_CLI_USER }}"
-    group: "{{ DEPLOYER_CLI_USER }}"
-    mode: "0600"
-    directory_mode: "0700"
+    - name: WORKSPACE CREDENTIALS - DEPLOY VAULT UTILITY SCRIPTS
+      ansible.builtin.copy:
+        src: "secrets-utils/"
+        dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets/"
+        owner: "{{ DEPLOYER_CLI_USER }}"
+        group: "{{ DEPLOYER_CLI_USER }}"
+        mode: "0600"
+        directory_mode: "0700"
 
-- name: WORKSPACE CREDENTIALS - CLEANUP UPLOADED TARBALL
-  ansible.builtin.file:
-    path: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-    state: absent
+  always:
+    - name: WORKSPACE CREDENTIALS - CLEANUP UPLOADED TARBALL
+      ansible.builtin.file:
+        path: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+        state: absent
+      failed_when: false
 
-- name: WORKSPACE CREDENTIALS - CLEANUP LOCAL TARBALL
-  ansible.builtin.file:
-    path: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
-    state: absent
-  delegate_to: localhost
-  become: false
+    - name: WORKSPACE CREDENTIALS - CLEANUP LOCAL TARBALL
+      ansible.builtin.file:
+        path: "/tmp/secrets-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.tar.gz"
+        state: absent
+      delegate_to: localhost
+      become: false
+      failed_when: false


### PR DESCRIPTION
## Summary

Fixes six HIGH-severity Ansible correctness issues identified in the code review: missing `changed_when` on shell tasks (breaking idempotency reporting and the bridge-apply conditional), oh-my-zsh clone creating root-owned files, vault cleartext leaking on `-v` runs, and the secrets tarball not cleaned up on failure.

## Changes

**proxmox.init — accurate change reporting**
- `CREATE LAB BRIDGES`: `changed_when` mirrors the `when` condition — bridge-apply step (`pvesh set`) now only fires when bridges were actually created
- `UPLOAD NAT INJECT SCRIPT`, `UPLOAD AND INJECT NAT`, `REMOVE NAT`, `CLEAN UP REMOTE INJECT SCRIPT`: `changed_when: true` (always modify state)
- `SET /ETC/DEFAULT/LOCALE`: `changed_when: true`
- Removed `EXPORT LOCALE IN REMOTE SESSION` task — `export` in a subshell has no effect; pure no-op

**proxmox.jump-user — accurate change reporting**
- `SET JUMP USER PASSWORD`: `changed_when: true`

**deployer.bootstrap — correct file ownership**
- `CLONE OH-MY-ZSH FOR DEPLOYER USER`: added `become: true` + `become_user: "{{ DEPLOYER_CLI_USER }}"` so cloned files are owned by the deployer user, not root

**credentials.vault — secrets protection**
- `RENDER VAULT CLEARTEXT FROM TEMPLATE`: added `no_log: true` so secrets are not printed to stdout on `-v` runs

**workspace.credentials — guaranteed tarball cleanup**
- Wrapped deploy tasks in `block:/always:` so both local (`/tmp/secrets-*.tar.gz`) and remote tarballs are deleted even if upload or extraction fails; cleanup tasks use `failed_when: false`

## Files Changed

| File | Change |
|------|--------|
| `roles/proxmox.init/tasks/03_create_network_bridge.yml` | `changed_when` on 5 tasks |
| `roles/proxmox.init/tasks/02_fix_remote_locale.yml` | `changed_when: true` on locale task; removed no-op export task |
| `roles/proxmox.jump-user/tasks/00_create_jump_user.yml` | `changed_when: true` on password task |
| `roles/deployer.bootstrap/tasks/03_shell.yml` | `become_user` on oh-my-zsh clone |
| `roles/credentials.vault/tasks/02_render_vault_cleartext.yml` | `no_log: true` |
| `roles/workspace.credentials/tasks/02_deploy_secrets.yml` | `block/always` wrapper |

## Testing

- [ ] Run playbook 02 twice — second run shows 0 changed for bridge tasks when bridges already exist
- [ ] Run playbook 01 with `-v` — vault render task shows `censored due to no_log`
- [ ] Interrupt playbook 03 after tarball upload — both tarballs absent after Ansible exits
- [ ] Verify `~/.oh-my-zsh` owned by deployer user after fresh deploy

## Related Issues

Companion to PR #83 (Ansible CRITICAL) and PR #84 (Python CRITICAL). Part of the range42 security/correctness hardening series.