### PR TITLE
fix(proxmox.init): always enable snippets storage, not only when apt proxy set

### DIFF
--- a/roles/proxmox.init/tasks/04_apt_proxy_snippet.yml
+++ b/roles/proxmox.init/tasks/04_apt_proxy_snippet.yml
@@ -13,11 +13,10 @@
 #       Run once: pvesm set local --content iso,vztmpl,backup,snippets
 #       Or in GUI: Datacenter → Storage → local → Edit → Content → tick "Snippets"
 
-- name: PROXMOX INIT - ENSURE SNIPPETS DIR EXISTS ON PROXMOX
+- name: PROXMOX INIT - ENABLE SNIPPETS CONTENT TYPE ON LOCAL STORAGE
   ansible.builtin.shell: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
-    "mkdir -p /var/lib/vz/snippets"
-  when: apt_proxy_url is defined and (apt_proxy_url | length) > 0
+    "pvesm set local --content iso,vztmpl,backup,snippets 2>/dev/null; mkdir -p /var/lib/vz/snippets"
   changed_when: false
 
 - name: PROXMOX INIT - RENDER APT PROXY SNIPPET LOCALLY


### PR DESCRIPTION
Fixes #101

## Summary

- `04_apt_proxy_snippet.yml`: remove `when: apt_proxy_url ...` guard from the snippets setup task and rename it to reflect its real scope
- Add `pvesm set local --content iso,vztmpl,backup,snippets` so the content type is properly registered in Proxmox (not just the directory created)

## Root cause

The task that creates `/var/lib/vz/snippets` was gated on `apt_proxy_url` being non-empty. The snippets directory is required by all scenario template playbooks to upload cloud-init `cicustom` snippets — not just apt-proxy setups. Setups without an apt proxy (the common case) never got the directory, causing scenario deployment to fail with `Destination directory /var/lib/vz/snippets does not exist`.

## Test plan

- [ ] Bootstrap without apt proxy (`apt_proxy_url: ""`), verify `/var/lib/vz/snippets` is created on Proxmox
- [ ] Bootstrap with apt proxy set, verify both the snippets dir and apt proxy snippet are created
- [ ] Re-run bootstrap (idempotency) — `pvesm set` and `mkdir -p` are both safe to run repeatedly