### PR TITLE
fix(proxmox.init): add IdentitiesOnly=yes to root key test and verify

### DIFF
--- a/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
+++ b/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
@@ -9,6 +9,7 @@
 - name: PROXMOX INIT - TEST IF ROOT KEY AUTH ALREADY WORKS
   ansible.builtin.command: >
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -o IdentitiesOnly=yes
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   register: root_ssh_test
   changed_when: false
@@ -66,6 +67,7 @@
 - name: PROXMOX INIT - VERIFY ROOT KEY AUTH WORKS AFTER INSTALL
   ansible.builtin.command: >
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -o IdentitiesOnly=yes
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   when: root_ssh_test.rc != 0
   changed_when: false


### PR DESCRIPTION
## Summary

- Adds `-o IdentitiesOnly=yes` to the root SSH key test in `proxmox.init`
- Adds `-o IdentitiesOnly=yes` to the post-install verify step for consistency

## Problem

Without `IdentitiesOnly=yes`, the test command `ssh -o BatchMode=yes root@<proxmox> true` falls back to trying all keys in the agent AND all default `~/.ssh/` key files. If the operator's personal key is already in Proxmox's `authorized_keys`, the test passes even though the workspace-specific key was never installed. The `ssh-copy-id` step is then skipped.

Result: `deploy` and `deploy-vms` fail with `Permission denied (publickey)` when the deployer-cli tries to connect to Proxmox using the workspace SSH key.

## Fix

`IdentitiesOnly=yes` constrains SSH to only the key loaded into the agent by the preceding `ssh-add` task — which is the workspace-specific key. The test now correctly reflects whether that key is accepted.

## Related

Closes #106
Discovered during validation run for #105