### PR TITLE
fix(proxmox.api-token): validate vault secret before use, auto-recover on stale token

### DIFF
--- a/roles/proxmox.api-token/tasks/01_create_or_import_token.yml
+++ b/roles/proxmox.api-token/tasks/01_create_or_import_token.yml
@@ -33,25 +33,42 @@
   no_log: true
   failed_when: false
 
-#### token already existed AND we have a secret in config — use it
+#### token already existed AND we have a secret in config — validate it first
 
-- name: PROXMOX API-TOKEN - USE SECRET FROM CONFIG (TOKEN ALREADY EXISTED)
+- name: PROXMOX API-TOKEN - VALIDATE SECRET FROM VAULT AGAINST LIVE TOKEN
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes"
+    method: GET
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
+    validate_certs: false
+    status_code: [200, 401, 403, 500]
+  register: vault_secret_validation
+  when:
+    - token_already_existed | bool
+    - proxmox_api_token_secret | default('') | length > 0
+  failed_when: false
+  no_log: true
+
+- name: PROXMOX API-TOKEN - USE SECRET FROM CONFIG (TOKEN ALREADY EXISTED, VALIDATED)
   ansible.builtin.set_fact:
     proxmox_api_token_secret_result: "{{ proxmox_api_token_secret }}"
   when:
     - token_already_existed | bool
     - proxmox_api_token_secret | default('') | length > 0
+    - vault_secret_validation.status | default(0) == 200
   no_log: true
 
-#### token already existed BUT no secret — auto-recovery: delete and recreate
+#### token already existed BUT secret is missing or stale — auto-recovery: delete and recreate
 
-- name: PROXMOX API-TOKEN - AUTO-RECOVERY — DELETE TOKEN (NO SECRET AVAILABLE)
+- name: PROXMOX API-TOKEN - AUTO-RECOVERY — DELETE TOKEN (NO SECRET OR STALE SECRET)
   ansible.builtin.shell: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pveum user token remove {{ proxmox_api_user }} {{ proxmox_api_token_id }} 2>&1 || true"
   when:
     - token_already_existed | bool
-    - proxmox_api_token_secret | default('') | length == 0
+    - (proxmox_api_token_secret | default('') | length == 0) or
+      (vault_secret_validation.status | default(0) != 200)
     - proxmox_api_token_secret_result is not defined
 
 - name: PROXMOX API-TOKEN - AUTO-RECOVERY — RECREATE TOKEN


### PR DESCRIPTION
## Summary

- Adds a lightweight `GET /api2/json/nodes` validation call before trusting a vault-stored API token secret
- Accepts the stored secret only when the API returns HTTP 200
- Falls through to the existing auto-recovery path (delete + recreate token) when the vault secret is absent **or** stale

## Problem

When a Proxmox API token already existed and the vault contained a `proxmox_api_token_secret` value, the role used it unconditionally:

```yaml
- name: PROXMOX API-TOKEN - USE SECRET FROM CONFIG (TOKEN ALREADY EXISTED)
  set_fact:
    proxmox_api_token_secret_result: "{{ proxmox_api_token_secret }}"
  when:
    - token_already_existed | bool
    - proxmox_api_token_secret | default('') | length > 0
```

If the vault was regenerated after a wipe-and-rerun (new vault, old Proxmox token), or if the Proxmox token was replaced externally, the stored secret would no longer match the live token. The role accepted it without question, and any subsequent API call using that secret would silently fail or hang.

The auto-recovery path (delete + recreate) only triggered when the vault was empty — not when it held a stale value.

## Fix

Before accepting the vault secret, a `GET /api2/json/nodes` call validates it. A 200 response means the secret is live and correct. Any other status (401, 403, 500) signals a mismatch — the auto-recovery condition is extended to also cover this case.

## Related

Closes #108
Discovered during validation run for #105