### PR TITLE
fix(wizard): replace shell=True subprocess and move credentials to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,48 @@ Once deployed, you manage your lab with the `range42-context` shell tool (switch
 
 ## Architecture overview
 
-A range42 deployment looks like this:
+A range42 deployment can be driven in two complementary ways:
+
+**Web UI path** (visual, recommended for day-to-day operations):
 
 ```
-   [ deployer-cli ]  ─── SSH / API ──▶  [ Proxmox + lab VMs ]
-      │
-      ├─ runs the wizard
-      ├─ holds inventory + credentials
-      └─ drives Ansible playbooks
+  ┌─ range42-deployer-ui (Vue 3 + VueFlow) ──────────────────┐
+  │  Visual topology canvas — drag-and-drop lab design        │
+  └──────────────────────────┬───────────────────────────────┘
+                             │ REST + WebSocket
+  ┌──────────────────────────▼───────────────────────────────┐
+  │  range42-api-gw (Kong gateway)                           │
+  │  Auth, ACLs, rate-limiting                               │
+  └──────────────────────────┬───────────────────────────────┘
+                             │
+  ┌──────────────────────────▼───────────────────────────────┐
+  │  range42-backend-api (FastAPI)                           │
+  │  80 REST endpoints + /ws/status stream                   │
+  └──────────┬───────────────────────┬───────────────────────┘
+             │                       │
+  range42-playbooks          range42-catalog
+  (scenarios + bundles)      (roles, Docker, CTF content)
+             │
+             ▼
+  [ Proxmox VE cluster ]
+  VMs, LXC, networks
 ```
+
+**CLI path** (direct, for advanced/scripted use):
+
+```
+  [ deployer-cli (range42-context) ]
+     │
+     ├─ runs the setup wizard
+     ├─ holds inventory + credentials
+     └─ drives Ansible playbooks directly
+             │
+             ▼
+  [ Proxmox VE cluster ]
+  VMs, LXC, networks
+```
+
+Both paths converge on the same Proxmox infrastructure and Ansible playbooks — the web UI simply adds a visual layer and a managed API on top.
 
 The **deployer-cli** is your local machine by default, or a dedicated pivot VM if you manage multiple Proxmox infrastructures from one place.
 
@@ -99,7 +132,7 @@ In its recommended configuration, range42 relies on:
 - **Docker / LXC** - containerized services and vulnerable stacks (recommended)
 - **Wazuh** - security monitoring and detection (optional)
 - **Firewalls / VPN** - network segmentation and access control (recommended)
-- **Vue.js / FastAPI / Kong** - web UI and API layer (optional)
+- **Vue.js / FastAPI / Kong** - web UI and API layer (available)
 
 ## Project mid / long term goals
 

--- a/range42-init.py
+++ b/range42-init.py
@@ -247,7 +247,7 @@ def _check_apt_proxy_reachable(url: str, timeout: float = 5.0):
         return False, f"{type(e).__name__}: {e}"
 
 # ── preflight (extracted to wizard/preflight.py) ──────────────────────────────
-from wizard.preflight import run_all_checks, get_apt_install_command
+from wizard.preflight import run_all_checks, get_apt_install_command, get_apt_install_packages
 
 # ── helpers ────────────────────────────────────────────────────────────────────
 def cmd_ok(c): return bool(shutil.which(c))
@@ -504,18 +504,9 @@ class StepPreflight(Step):
             self.app.call_from_thread(self._row, r["badge"], r["label"], r["detail"])
             time.sleep(0.12)
 
-        self._apt_cmd = get_apt_install_command(results)
+        self._apt_cmd = get_apt_install_packages(results)  # list of packages (not a shell string)
         S.preflight_ok = not fail
         self.app.call_from_thread(self._done, fail)
-
-    def _add_row(self, badge, msg, kv=""):
-        cls = {"PASS":"pf-badge-pass","WARN":"pf-badge-warn",
-               "FAIL":"pf-badge-fail","INFO":"pf-badge-info"}[badge]
-        row = Horizontal(classes="pf-row")
-        row.compose_add_child(Label(badge, classes=cls))
-        row.compose_add_child(Label(msg,   classes="pf-msg"))
-        row.compose_add_child(Label(kv,    classes="pf-kv"))
-        self.query_one("#pf-rows").mount(row)
 
     def _row(self, badge, msg, kv=""):
         cls = {"PASS":"pf-badge-pass","WARN":"pf-badge-warn",
@@ -1579,11 +1570,11 @@ def post_wizard():
         _print_info("proxmox root password not set — you will be prompted")
 
     if S.deployer_ip not in ("127.0.0.1", "localhost") and S.deployer_cli_pw:
-        extra += ["-e", f"ansible_ssh_pass={S.deployer_cli_pw}"]
+        env["ANSIBLE_SSH_PASS"] = S.deployer_cli_pw
         _print_ok("deployer-cli password provided")
 
     if S.sudo_pw:
-        extra += ["-e", f"ansible_become_pass={S.sudo_pw}"]
+        env["ANSIBLE_BECOME_PASS"] = S.sudo_pw
         _print_ok("sudo password provided")
     else:
         _print_info("sudo password not set — assuming NOPASSWD")
@@ -1699,9 +1690,13 @@ if __name__ == "__main__":
     # post-TUI: if user clicked "Install prerequisites", run apt then re-launch
     if app._install_cmd:
         print()
-        print(f"  \033[1;33mINFO\033[0m  running: {app._install_cmd}")
+        print(f"  \033[1;33mINFO\033[0m  installing packages: {' '.join(app._install_cmd)}")
         print()
-        rc = subprocess.call(app._install_cmd, shell=True)
+        rc = subprocess.run(["sudo", "apt-get", "update"], check=False).returncode
+        if rc == 0:
+            rc = subprocess.run(
+                ["sudo", "apt-get", "install", "-y", *app._install_cmd], check=False
+            ).returncode
         if rc == 0:
             print()
             print("  \033[1;32m   OK\033[0m  packages installed — restarting wizard...")
@@ -1719,7 +1714,7 @@ if __name__ == "__main__":
         else:
             print()
             print("  \033[1;31m FAIL\033[0m  install failed — run manually:")
-            print(f"         {app._install_cmd}")
+            print(f"         sudo apt-get update && sudo apt-get install -y {' '.join(app._install_cmd)}")
             print(f"         then: python3 {__file__}")
             sys.exit(1)
     post_wizard()

--- a/wizard/preflight.py
+++ b/wizard/preflight.py
@@ -181,11 +181,11 @@ def run_all_checks(example_dir):
     return results, fail
 
 
-def get_apt_install_command(results):
+def get_apt_install_packages(results) -> list:
     """
-    Build a single 'sudo apt-get install ...' command from failed/warned checks.
-    Only includes checks that have an apt fix (not manual).
-    Returns None if nothing to install.
+    Return a sorted list of package names that need to be installed.
+    Only includes checks that have an apt fix (not manual) and are FAIL or WARN.
+    Returns an empty list if nothing to install.
     """
     packages = set()
     for r in results:
@@ -194,9 +194,19 @@ def get_apt_install_command(results):
             # extract package name from "sudo apt install <pkg>"
             pkg = apt_fix.replace("sudo apt install ", "").strip()
             packages.add(pkg)
+    return sorted(packages)
+
+
+def get_apt_install_command(results):
+    """
+    Build a single 'sudo apt-get install ...' command from failed/warned checks.
+    Only includes checks that have an apt fix (not manual).
+    Returns None if nothing to install (used for display / button visibility).
+    """
+    packages = get_apt_install_packages(results)
     if not packages:
         return None
-    return "sudo apt-get update && sudo apt-get install -y " + " ".join(sorted(packages))
+    return "sudo apt-get update && sudo apt-get install -y " + " ".join(packages)
 
 
 # files required in each scenario's templates/ dir for it to be deployable


### PR DESCRIPTION
## Summary

Fixes two critical security issues identified in #114.

### Fix 1 — `subprocess.call(shell=True)` → `shell=False`

`app._install_cmd` was built as a shell string and passed to `subprocess.call(..., shell=True)`, creating a command-injection surface if any `CHECKS` entry ever contained shell metacharacters.

**Changes:**
- Added `get_apt_install_packages(results) -> list` in `wizard/preflight.py` that returns a sorted list of package names (no shell string)
- `get_apt_install_command()` now delegates to it and is kept for display / button-visibility use only
- `StepPreflight.check()` stores the package list (not a shell string) in `self._apt_cmd` — truthiness check in `_done()` still works correctly
- Post-TUI install block uses two explicit `subprocess.run(["sudo", "apt-get", ...], check=False)` calls with `shell=False`

### Fix 2 — Credentials removed from process argv

`ansible_ssh_pass` and `ansible_become_pass` were passed as `-e` extra-vars on the `ansible-playbook` command line, making passwords visible to all users via `ps aux`.

**Changes:**
- Both passwords are now set as `ANSIBLE_SSH_PASS` and `ANSIBLE_BECOME_PASS` environment variables, consistent with how `proxmox_root_pw` was already handled via `env["ANSIBLE_SSH_PASS"]`
- The two `extra += ["-e", "ansible_*=..."]` lines are removed; `extra` list remains for other uses

## Test plan

- [ ] Run `python3 range42-init.py` on a machine missing some prerequisites — confirm "Install prerequisites" button appears and clicking it runs `apt-get` without a shell
- [ ] Verify `ps aux` during an ansible-playbook run no longer shows `ansible_ssh_pass=` or `ansible_become_pass=` in the command line
- [ ] Confirm `ansible-playbook` still receives passwords correctly via `ANSIBLE_SSH_PASS` / `ANSIBLE_BECOME_PASS` env vars
- [ ] Verify `get_apt_install_command()` still returns a displayable string for the UI (used only for button visibility, not execution)

Closes #114