### PR TITLE
fix(configuration.validate): enforce minimum complexity for jump_password

### DIFF
--- a/roles/configuration.validate/tasks/main.yml
+++ b/roles/configuration.validate/tasks/main.yml
@@ -36,3 +36,26 @@
     - { name: "DEPLOYER_CLI_USER",               value: "{{ DEPLOYER_CLI_USER | default('your_deployer_cli_username') }}" }
   loop_control:
     label: "{{ item.name }}"
+
+- name: VALIDATE - CHECK JUMP_PASSWORD COMPLEXITY
+  ansible.builtin.assert:
+    that:
+      - jump_password is defined
+      - jump_password | length >= 12
+      - jump_password | regex_search('[A-Z]')
+      - jump_password | regex_search('[a-z]')
+      - jump_password | regex_search('[0-9]')
+    fail_msg: |
+
+      #### #### #### #### #### #### #### #### #### #### ####
+
+      WEAK PASSWORD: jump_password
+
+      jump_password must be at least 12 characters and contain
+      uppercase, lowercase, and a digit.
+
+      Please edit your vault file:
+        inventories/<codename>/group_vars/<scenario>/vault.yml
+
+      #### #### #### #### #### #### #### #### #### #### ####
+    quiet: true


### PR DESCRIPTION
Closes #93

## Summary

Add an assert block to `roles/configuration.validate/tasks/main.yml` that rejects `jump_password` values shorter than 12 characters or missing uppercase, lowercase, or a digit. Fails early with a clear message pointing to the vault file.

## Test plan
- [ ] Run with a weak password — deployment fails at validate step with the message above
- [ ] Run with a valid 12+ char mixed password — validation passes