### PR TITLE
fix(proxmox.jump-user): force password change on first login

### DIFF
--- a/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
+++ b/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
@@ -29,3 +29,10 @@
     "echo '{{ jump_user }}:{{ jump_password }}' | chpasswd"
   when: jump_on_proxmox | default('YES') | upper == 'YES'
   no_log: true
+
+- name: PROXMOX JUMP-USER - FORCE PASSWORD CHANGE ON FIRST LOGIN
+  ansible.builtin.command: >
+    ssh root@{{ jump_host }}
+    chage -d 0 {{ jump_user }}
+  when: jump_on_proxmox | default('YES') | upper == 'YES'
+  changed_when: true


### PR DESCRIPTION
Closes #94

## Summary

Add `chage -d 0 <jump_user>` after `chpasswd` in `roles/proxmox.jump-user/tasks/00_create_jump_user.yml`. The jump user must choose a new password on first interactive SSH login.

## Test plan
- [ ] Deploy to a test Proxmox host — jump user is prompted to change password on first login
- [ ] Second login with the new password succeeds normally