### PR TITLE
fix(callback): correct no_skipped plugin — suppress loop item skips without hiding failures

### DIFF
--- a/callback_plugins/no_skipped.py
+++ b/callback_plugins/no_skipped.py
@@ -1,17 +1,22 @@
+# Ansible callback plugin that suppresses skipped-task output.
+# Inherits everything from the default callback; only overrides the two
+# "skipped" display methods. Failures are never affected.
+#
+# Enable in ansible.cfg:
+#   [defaults]
+#   stdout_callback = no_skipped
 from ansible.plugins.callback.default import CallbackModule as DefaultCallbackModule
 
 
 class CallbackModule(DefaultCallbackModule):
-    """
-    from 'classic' callback  :: remove 'skipped' events. (to debug)
-
-    """
-
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = "stdout"
     CALLBACK_NAME = "no_skipped"
     CALLBACK_NEEDS_WHITELIST = False
+    CALLBACK_NEEDS_ENABLED = False
 
     def v2_runner_on_skipped(self, result):
-        # attempt to overwrite the methode to avoid printing skipped task.
-        return
+        pass
+
+    def v2_runner_item_on_skipped(self, result):
+        pass


### PR DESCRIPTION
Closes #96

## Summary

The previous `no_skipped` callback only overrode `v2_runner_on_skipped`, leaving loop-item skip lines visible. This adds the missing `v2_runner_item_on_skipped` override. Failures (`v2_runner_on_failed`, `v2_runner_item_on_failed`) are inherited unchanged.

Also removes the stale docstring and replaces `return` with `pass` for clarity.

## Test plan
- [ ] Run a playbook with skipped tasks — no `skipping: [host]` lines appear
- [ ] Run a playbook with a failing task — failure output still prints
- [ ] Run a playbook with a failing loop item — failure still prints, skipped items do not