### PR TITLE
fix(credentials.generate): auto-migrate additionnal.students → additional.students

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,15 @@
+# Migration Notes
+
+## additionnal.students → additional.students (PR #88)
+
+A typo in the student SSH key directory name was corrected. Operators who ran a
+deployment before this fix will have the old directory name on disk.
+
+**Automatic:** the `credentials.generate` role detects and renames the old
+directory on the next run (`ansible-playbook site.yml ...`).
+
+**Manual (if needed):**
+```bash
+find config/ -type d -name "additionnal.students" \
+  -execdir mv {} additional.students \;
+```

--- a/roles/credentials.generate/tasks/00_create_directories.yml
+++ b/roles/credentials.generate/tasks/00_create_directories.yml
@@ -10,4 +10,12 @@
     - "{{ credentials_output_dir }}/ssh_keys/jump_keys"
     - "{{ credentials_output_dir }}/ssh_keys/backend_keys"
     - "{{ credentials_output_dir }}/ssh_keys/student_keys"
-    - "{{ credentials_output_dir }}/ssh_keys/student_keys/additionnal.students"
+    - "{{ credentials_output_dir }}/ssh_keys/student_keys/additional.students"
+
+- name: CREDENTIALS GENERATE - MIGRATE additionnal.students → additional.students
+  ansible.builtin.command:
+    cmd: >
+      mv {{ credentials_output_dir }}/ssh_keys/student_keys/additionnal.students
+         {{ credentials_output_dir }}/ssh_keys/student_keys/additional.students
+    removes: "{{ credentials_output_dir }}/ssh_keys/student_keys/additionnal.students"
+  changed_when: true


### PR DESCRIPTION
Closes #100

## Summary

- Corrects the directory name in the `CREATE SSH KEYS DIRECTORIES` loop (`additionnal` → `additional`)
- Adds a migration task that renames the old directory on the next run for operators with existing deployments (`removes:` guard makes it a no-op if the old dir is gone)
- Adds `MIGRATION.md` documenting the change and the manual one-liner fallback

## Test plan
- [ ] Create a dummy `additionnal.students` dir and run `credentials.generate` — it is renamed
- [ ] Run again — idempotent, no change reported