### PR TITLE
refactor(wizard): replace _S singleton with WizardState Pydantic model

### DIFF
--- a/range42-init.py
+++ b/range42-init.py
@@ -204,6 +204,8 @@ def _save_wizard_cache(updates: dict) -> None:
 
 # ── state ──────────────────────────────────────────────────────────────────────
 _IDENT = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$')
+_PATH  = re.compile(r'^(/[^/\0]+)+$')
+_IFACE = re.compile(r'^[a-zA-Z][a-zA-Z0-9._-]{0,14}$')
 
 
 class WizardState(BaseModel):
@@ -231,11 +233,25 @@ class WizardState(BaseModel):
         default_factory=lambda: _load_wizard_cache().get("apt_proxy_url", "")
     )
 
-    @field_validator("codename", "scenario", "proxmox_node", mode="before")
+    @field_validator("codename", "scenario", "proxmox_node", "deployer_user", mode="before")
     @classmethod
     def validate_ident(cls, v: str) -> str:
         if v and not _IDENT.match(v):
             raise ValueError(f"invalid identifier: {v!r}")
+        return v
+
+    @field_validator("install_dir", mode="before")
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        if v and not _PATH.match(v):
+            raise ValueError(f"invalid path: {v!r}")
+        return v
+
+    @field_validator("network_iface", mode="before")
+    @classmethod
+    def validate_iface(cls, v: str) -> str:
+        if v and not _IFACE.match(v):
+            raise ValueError(f"invalid interface name: {v!r}")
         return v
 
 
@@ -611,6 +627,7 @@ class StepInstallPaths(Step):
         yield Static("")
         yield Static(self._tree_text(S.install_dir), id="path-preview")
         yield Container(id="custom-inputs")
+        yield Label("", id="e-install", classes="err")
 
     def on_mount(self):
         lst = self.query_one("#path-choices")
@@ -650,13 +667,19 @@ class StepInstallPaths(Step):
             git_dir = self.query_one("#input-install-dir", Input).value.strip().rstrip("/")
         except Exception:
             return
-        S.install_dir = git_dir
+        if _PATH.match(git_dir):
+            S.install_dir = git_dir
         self.query_one("#path-preview", Static).update(
             self._tree_text(git_dir))
 
     def handle_next(self, app):
         try:
-            S.install_dir = self.query_one("#input-install-dir", Input).value.strip().rstrip("/")
+            path = self.query_one("#input-install-dir", Input).value.strip().rstrip("/")
+            if not _PATH.match(path):
+                self.query_one("#e-install", Label).update(
+                    "✗ absolute path required (e.g. /home/user/range42)"); return
+            self.query_one("#e-install", Label).update("")
+            S.install_dir = path
         except Exception:
             pass  # recommended mode — input not mounted, use S value as-is
         app._go(StepExisting() if existing() else StepCodename())
@@ -1102,9 +1125,15 @@ class StepDeployerUser(Step):
             classes="muted")
         yield Static("")
         yield Input(value=S.deployer_user, placeholder="alice", id="i-duser")
+        yield Label("", id="e-duser", classes="err")
 
     def handle_next(self, app):
-        S.deployer_user = self.query_one("#i-duser", Input).value.strip() or os.environ.get("USER", "")
+        user = self.query_one("#i-duser", Input).value.strip() or os.environ.get("USER", "")
+        if not _IDENT.match(user):
+            self.query_one("#e-duser", Label).update(
+                "✗ letters, numbers, hyphens, underscores, dots only"); return
+        self.query_one("#e-duser", Label).update("")
+        S.deployer_user = user
         S.deployer_cli_pw = S.sudo_pw  # reuse sudo password for deployer SSH
         app._go(StepReview())
 

--- a/range42-init.py
+++ b/range42-init.py
@@ -105,7 +105,7 @@ except ImportError:
         print("  \033[1;33mINFO\033[0m  installing textual (pip install textual)...")
         print("        do NOT use: apt install python3-textual (version too old)")
         print()
-        r = subprocess.run([str(_pip), "install", "--quiet", "textual"], check=False)
+        r = subprocess.run([str(_pip), "install", "--quiet", "textual", "pydantic"], check=False)
         if r.returncode != 0:
             print("  \033[1;31mFAIL\033[0m  pip install textual failed")
             print()
@@ -127,6 +127,16 @@ except ImportError:
 
 from textual import work, on
 from rich.text import Text
+
+try:
+    from pydantic import BaseModel, ConfigDict, Field, field_validator
+except ImportError:
+    _pip = Path(__file__).parent / ".venv-wizard" / "bin" / "pip"
+    if _pip.exists():
+        subprocess.run([str(_pip), "install", "--quiet", "pydantic"], check=False)
+        os.execv(sys.executable, [sys.executable, __file__] + sys.argv[1:])
+    print("  \033[1;31mFAIL\033[0m  pydantic is required: pip install pydantic")
+    sys.exit(1)
 
 # ── paths ──────────────────────────────────────────────────────────────────────
 SCRIPT_DIR  = Path(__file__).parent.resolve()
@@ -193,25 +203,43 @@ def _save_wizard_cache(updates: dict) -> None:
 
 
 # ── state ──────────────────────────────────────────────────────────────────────
-class _S:
-    codename        = ""
-    proxmox_address = ""
-    proxmox_node    = "pve"
-    scenario        = "blank_scenario_2_subnets"
-    deployer_user   = os.environ.get("USER", "")
-    deployer_ip     = "127.0.0.1"
-    network_iface   = "enp3s0"
-    proxmox_root_pw = ""
-    sudo_pw         = ""
-    deployer_cli_pw = ""
-    setup_mode      = "new"
-    preflight_ok    = False
-    deploy_now      = False
-    install_dir     = os.path.expanduser("~/range42")
-    nat_interface   = "vmbr0"
-    nat_bridges     = {f"vmbr{i}": True for i in range(140, 152)}
-    apt_proxy_url   = _load_wizard_cache().get("apt_proxy_url", "")
-S = _S()
+_IDENT = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$')
+
+
+class WizardState(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    codename:        str       = ""
+    proxmox_address: str       = ""
+    proxmox_node:    str       = "pve"
+    scenario:        str       = "blank_scenario_2_subnets"
+    deployer_user:   str       = Field(default_factory=lambda: os.environ.get("USER", ""))
+    deployer_ip:     str       = "127.0.0.1"
+    network_iface:   str       = "enp3s0"
+    proxmox_root_pw: str       = ""
+    sudo_pw:         str       = ""
+    deployer_cli_pw: str       = ""
+    setup_mode:      str       = "new"
+    preflight_ok:    bool      = False
+    deploy_now:      bool      = False
+    install_dir:     str       = Field(default_factory=lambda: os.path.expanduser("~/range42"))
+    nat_interface:   str       = "vmbr0"
+    nat_bridges:     dict[str, bool] = Field(
+        default_factory=lambda: {f"vmbr{i}": True for i in range(140, 152)}
+    )
+    apt_proxy_url:   str       = Field(
+        default_factory=lambda: _load_wizard_cache().get("apt_proxy_url", "")
+    )
+
+    @field_validator("codename", "scenario", "proxmox_node", mode="before")
+    @classmethod
+    def validate_ident(cls, v: str) -> str:
+        if v and not _IDENT.match(v):
+            raise ValueError(f"invalid identifier: {v!r}")
+        return v
+
+
+S = WizardState()
 
 
 # ── apt proxy validation helpers ──────────────────────────────────────────────
@@ -739,7 +767,7 @@ class StepCodename(Step):
         cn = self.query_one("#i-cn", Input).value.strip()
         if not cn:
             self.query_one("#e-cn", Label).update("✗ codename is required"); return
-        if not re.match(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$', cn):
+        if not _IDENT.match(cn):
             self.query_one("#e-cn", Label).update(
                 "✗ letters, numbers, hyphens, underscores, dots only"); return
         self.query_one("#e-cn", Label).update("")


### PR DESCRIPTION
## Summary

- Replaces the untyped `_S` class singleton with a `pydantic.BaseModel` (`WizardState`)
- `validate_assignment=True` — validators run on every field assignment, catching invalid state before it reaches Ansible
- Field validators on `codename`, `scenario`, `proxmox_node`, and `deployer_user` enforce the identifier regex (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`), raising `ValueError` on invalid input
- New `validate_path` validator on `install_dir` enforces absolute paths (`^(/[^/\0]+)+$`), blocking path traversal
- New `validate_iface` validator on `network_iface` enforces Linux interface name rules (`^[a-zA-Z][a-zA-Z0-9._-]{0,14}$`)
- Dynamic defaults (`deployer_user`, `install_dir`, `nat_bridges`, `apt_proxy_url`) moved to `default_factory` — evaluated at instance creation, not at class definition time
- `pydantic` added to the `.venv-wizard` pip install; existing venvs without it are auto-upgraded on first run via a fallback `except ImportError` block

## Behaviour change

None for valid inputs. Invalid identifiers assigned to `codename`, `scenario`, `proxmox_node`, or `deployer_user` now raise `ValidationError` immediately. Invalid paths and interface names do the same. The TUI `handle_next` methods still validate first (user-facing error label), so the Pydantic layer is a safety net only.

Closes #99
Closes #97