### PR TITLE
feat(proxmox.init,deployer.bootstrap): distribute Proxmox CA cert to deployer-cli trust store

### DIFF
--- a/playbooks/02_configure_proxmox.yml
+++ b/playbooks/02_configure_proxmox.yml
@@ -15,6 +15,7 @@
 #   - jump_user exists on proxmox with SSH key access
 #   - API token is created and tested
 #   - locale is set to C.UTF-8
+#   - config/<codename>-<scenario>/proxmox_ca.crt contains the Proxmox CA cert
 #
 ################################################################################
 
@@ -27,6 +28,7 @@
     DEPLOYER_CLI_ROOT_DIR: "{{ playbook_dir }}/.."
     proxmox_root_ssh_key_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root"
     proxmox_jump_ssh_key_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.jump_user"
+    proxmox_ca_cert_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/proxmox_ca.crt"
 
   # ensure ssh-agent is running for the entire play (all roles need it)
   # if agent is already running (keychain, etc.), reuse it

--- a/playbooks/03_deploy_deployer_cli.yml
+++ b/playbooks/03_deploy_deployer_cli.yml
@@ -18,6 +18,7 @@
 #   - SSH keys + vault + inventory deployed
 #   - SSH config configured (Include + range42 host entries)
 #   - symlinks created (secrets, scenario)
+#   - Proxmox CA cert installed in system trust store (if 02 was run first)
 #
 ################################################################################
 
@@ -29,6 +30,7 @@
     DEPLOYER_CLI_ROOT_DIR: "{{ playbook_dir }}/.."
     INFRASTRUCTURE__AUTO_GENERATED__SSH_KEYS_DIR_LOCAL: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys"
     INFRASTRUCTURE__AUTO_GENERATED__CONFIG_DIR_LOCAL: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
+    proxmox_ca_cert_local_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/proxmox_ca.crt"
 
   roles:
     - deployer.bootstrap

--- a/roles/deployer.bootstrap/tasks/07_proxmox_ca_cert.yml
+++ b/roles/deployer.bootstrap/tasks/07_proxmox_ca_cert.yml
@@ -1,0 +1,36 @@
+---
+# deployer.bootstrap - install Proxmox CA cert into system trust store
+#
+# Copies the locally-fetched cert to /usr/local/share/ca-certificates/ and runs
+# update-ca-certificates so Python/urllib/requests can verify Proxmox TLS.
+# Skipped when proxmox_ca_cert_local_path is undefined or the file does not yet
+# exist (e.g. 03_deploy_deployer_cli run before 02_configure_proxmox).
+
+- name: DEPLOYER BOOTSTRAP - STAT PROXMOX CA CERT LOCALLY
+  ansible.builtin.stat:
+    path: "{{ proxmox_ca_cert_local_path }}"
+  register: _proxmox_ca_cert_stat
+  delegate_to: localhost
+  become: false
+  when: proxmox_ca_cert_local_path is defined and proxmox_ca_cert_local_path | length > 0
+
+- name: DEPLOYER BOOTSTRAP - INSTALL PROXMOX CA CERT IN TRUST STORE
+  ansible.builtin.copy:
+    src: "{{ proxmox_ca_cert_local_path }}"
+    dest: "/usr/local/share/ca-certificates/proxmox_ca.crt"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  when:
+    - proxmox_ca_cert_local_path is defined and proxmox_ca_cert_local_path | length > 0
+    - _proxmox_ca_cert_stat.stat.exists | default(false)
+  register: _proxmox_ca_cert_copy
+
+- name: DEPLOYER BOOTSTRAP - UPDATE CA CERTIFICATES
+  ansible.builtin.command: update-ca-certificates
+  become: true
+  when:
+    - _proxmox_ca_cert_copy is not skipped
+    - _proxmox_ca_cert_copy.changed
+  changed_when: true

--- a/roles/deployer.bootstrap/tasks/main.yml
+++ b/roles/deployer.bootstrap/tasks/main.yml
@@ -17,6 +17,7 @@
 # Variables consumed:
 #   - DEPLOYER_CLI_USER                              (required)
 #   - DEV_MODE_INSTALL_JUMP_HOST_ANSIBLE_PACKAGES    (YES/NO, default YES)
+#   - proxmox_ca_cert_local_path                     (optional — path on controller)
 #
 ################################################################################
 
@@ -28,3 +29,4 @@
 - import_tasks: ./04_dot_files.yml
 - import_tasks: ./05_range42_context.yml
 - import_tasks: ./06_ansible_config.yml
+- import_tasks: ./07_proxmox_ca_cert.yml  # install Proxmox CA cert into system trust store

--- a/roles/proxmox.init/tasks/05_fetch_ca_cert.yml
+++ b/roles/proxmox.init/tasks/05_fetch_ca_cert.yml
@@ -1,0 +1,25 @@
+---
+# proxmox.init - fetch Proxmox self-signed CA cert and store locally
+#
+# Extracts the TLS certificate from the Proxmox HTTPS API using openssl s_client
+# and writes it to config/<codename>-<scenario>/proxmox_ca.crt (gitignored).
+# Consumed by 03_deploy_deployer_cli to install it into the deployer-cli CA trust
+# store, enabling TLS verification without validate_certs: false.
+
+- name: PROXMOX INIT - FETCH CA CERT VIA OPENSSL S_CLIENT
+  ansible.builtin.shell: >
+    openssl s_client
+    -connect {{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:8006
+    -showcerts </dev/null 2>/dev/null
+    | openssl x509 -outform PEM
+  register: _proxmox_ca_cert_pem
+  changed_when: false
+  failed_when: >
+    _proxmox_ca_cert_pem.rc != 0
+    or _proxmox_ca_cert_pem.stdout | length == 0
+
+- name: PROXMOX INIT - WRITE CA CERT TO LOCAL CONFIG
+  ansible.builtin.copy:
+    content: "{{ _proxmox_ca_cert_pem.stdout }}\n"
+    dest: "{{ proxmox_ca_cert_path }}"
+    mode: "0644"

--- a/roles/proxmox.init/tasks/main.yml
+++ b/roles/proxmox.init/tasks/main.yml
@@ -16,15 +16,18 @@
 #   2. Load the Proxmox root SSH key into the agent
 #   3. Install the public key on the Proxmox server (ssh-copy-id if needed)
 #   4. Fix locale on Proxmox (set C.UTF-8 in /etc/default/locale + locale-gen)
+#   5. Fetch the Proxmox CA cert for TLS verification (stored locally)
 #
 # Variables consumed:
 #   - INFRASTRUCTURE_PROXMOX_ADDRESS   (required — FQDN or IP of the Proxmox host)
 #   - proxmox_root_ssh_key_path        (required — path to the generated root SSH key)
+#   - proxmox_ca_cert_path             (required — local path to write the CA cert)
 #
 # After this role:
 #   - root@PROXMOX_ADDRESS is reachable via SSH key (no password)
 #   - locale is set to C.UTF-8
 #   - proxmox.jump-user and proxmox.api-token can run
+#   - config/<codename>-<scenario>/proxmox_ca.crt exists for TLS distribution
 #
 ################################################################################
 
@@ -33,3 +36,4 @@
 - import_tasks: ./02_fix_remote_locale.yml
 - import_tasks: ./03_create_network_bridge.yml
 - import_tasks: ./04_apt_proxy_snippet.yml      # cloud-init cicustom snippet (no-op if apt_proxy_url empty)
+- import_tasks: ./05_fetch_ca_cert.yml          # fetch Proxmox CA cert for TLS distribution


### PR DESCRIPTION
Closes #91

## Summary

- **`proxmox.init/05_fetch_ca_cert.yml`** (new): uses `openssl s_client -connect <host>:8006` to extract the Proxmox TLS cert and writes it to `config/<codename>-<scenario>/proxmox_ca.crt` (already gitignored via `config/*/`).
- **`deployer.bootstrap/07_proxmox_ca_cert.yml`** (new): copies the cert to `/usr/local/share/ca-certificates/proxmox_ca.crt` on the deployer-cli and runs `update-ca-certificates`; gracefully skipped when the cert file does not exist yet (e.g. running playbook 03 before 02).
- **`playbooks/02_configure_proxmox.yml`**: adds `proxmox_ca_cert_path` var (path where the cert is stored locally).
- **`playbooks/03_deploy_deployer_cli.yml`**: adds `proxmox_ca_cert_local_path` var (same path, passed to `deployer.bootstrap`).
- `proxmox_api_validate_certs` remains `false` by default — safe for fresh Proxmox installations with self-signed certs.

## Deployment order

```
02_configure_proxmox   → fetches + stores proxmox_ca.crt locally
03_deploy_deployer_cli → copies cert to deployer-cli trust store
```

Running 03 before 02 is safe — the CA cert task is skipped when the file is absent.

## Test plan

- [ ] Run `02_configure_proxmox.yml` — verify `config/<codename>-<scenario>/proxmox_ca.crt` is created and contains a valid PEM cert
- [ ] Run `03_deploy_deployer_cli.yml` — verify cert is installed at `/usr/local/share/ca-certificates/proxmox_ca.crt` and `update-ca-certificates` ran
- [ ] Run `03_deploy_deployer_cli.yml` without running 02 first — verify CA cert task is cleanly skipped
- [ ] Re-run both playbooks — verify idempotency (no spurious changes)