### PR TITLE
feat(proxmox.api-token): least-privilege range42-operator role replaces Administrator

### DIFF
--- a/roles/proxmox.api-token/tasks/00_create_operator_role.yml
+++ b/roles/proxmox.api-token/tasks/00_create_operator_role.yml
@@ -1,0 +1,20 @@
+---
+# proxmox api-token - create range42-operator custom role (least-privilege)
+#
+# Creates a custom Proxmox role with the minimal set of privileges required
+# by range42 playbooks, replacing the built-in Administrator grant.
+# Idempotent: pveum role add exits non-zero if role exists; the error is
+# suppressed with || true (same pattern as 00_create_api_user.yml).
+
+- name: PROXMOX API-TOKEN - CREATE RANGE42-OPERATOR ROLE (SKIP IF EXISTS)
+  ansible.builtin.shell: >
+    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    "pveum role add range42-operator
+    --privs 'Datastore.AllocateSpace,Datastore.AllocateTemplate,SDN.Use,VM.Allocate,VM.Clone,VM.Config.CDROM,VM.Config.CPU,VM.Config.Cloudinit,VM.Config.Disk,VM.Config.HWType,VM.Config.Memory,VM.Config.Net,VM.Config.Options,VM.Console,VM.PowerMgmt,VM.Snapshot,VM.Snapshot.Rollback'
+    2>&1 || true"
+  register: _role_create
+  changed_when: "'already exists' not in _role_create.stdout"
+
+- name: PROXMOX API-TOKEN - DISPLAY OPERATOR ROLE STATUS
+  ansible.builtin.debug:
+    msg: "{{ ('already exists' in _role_create.stdout) | ternary('range42-operator role already exists — ok', 'range42-operator role created') }}"

--- a/roles/proxmox.api-token/tasks/02_grant_acl.yml
+++ b/roles/proxmox.api-token/tasks/02_grant_acl.yml
@@ -1,10 +1,18 @@
 ---
-# proxmox api-token - grant administrator acl on / for the api user
+# proxmox api-token - grant range42-operator role on / for the api user
 #
-# source: proxmox_generate_api_credentials() lines 1096-1097
+# Revokes the Administrator role previously granted (migration, no-op if not
+# set) and grants the least-privilege range42-operator role instead.
+# The range42-operator role is created in 00_create_operator_role.yml.
 
-- name: PROXMOX API-TOKEN - GRANT ADMINISTRATOR ROLE ON /
+- name: PROXMOX API-TOKEN - REVOKE ADMINISTRATOR ROLE ON / (MIGRATION)
+  ansible.builtin.shell: >
+    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    "pveum acl modify / -user {{ proxmox_api_user }} -role Administrator -delete 2>&1 || true"
+  changed_when: false
+
+- name: PROXMOX API-TOKEN - GRANT RANGE42-OPERATOR ROLE ON /
   ansible.builtin.command: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
-    pveum acl modify / -user {{ proxmox_api_user }} -role Administrator
+    pveum acl modify / -user {{ proxmox_api_user }} -role range42-operator
   changed_when: true

--- a/roles/proxmox.api-token/tasks/main.yml
+++ b/roles/proxmox.api-token/tasks/main.yml
@@ -13,11 +13,12 @@
 #
 # What this role does:
 #   1. Create PVE user (pveum user add) if it doesn't exist
-#   2. Check if API token already exists (pveum user token list)
-#   3. If token exists → use secret from config (or parent_config)
-#   4. If token does not exist → create it (pveum user token add --privsep 0)
-#   5. Grant Administrator ACL on / (pveum acl modify)
-#   6. Test the API token via curl (GET /api2/json/nodes)
+#   2. Create range42-operator custom role (least-privilege, skip if exists)
+#   3. Check if API token already exists (pveum user token list)
+#   4. If token exists → use secret from config (or parent_config)
+#   5. If token does not exist → create it (pveum user token add --privsep 0)
+#   6. Grant range42-operator ACL on / — revoke Administrator first (migration)
+#   7. Test the API token via curl (GET /api2/json/nodes)
 #
 # Variables consumed:
 #   - INFRASTRUCTURE_PROXMOX_ADDRESS       (required)
@@ -32,6 +33,7 @@
 ################################################################################
 
 - import_tasks: ./00_create_api_user.yml
+- import_tasks: ./00_create_operator_role.yml
 - import_tasks: ./01_create_or_import_token.yml
 - import_tasks: ./02_grant_acl.yml
 - import_tasks: ./03_test_api_token.yml


### PR DESCRIPTION
Closes #92

## Summary

- **`roles/proxmox.api-token/tasks/00_create_operator_role.yml`** (new): creates the `range42-operator` custom Proxmox role with only the privileges range42 actually needs — `VM.Allocate`, `VM.Clone`, `VM.Config.*`, `VM.Console`, `VM.PowerMgmt`, `VM.Snapshot.*`, `Datastore.AllocateSpace`, `Datastore.AllocateTemplate`, `SDN.Use`. Idempotent (`|| true` pattern, same as `00_create_api_user.yml`).
- **`roles/proxmox.api-token/tasks/02_grant_acl.yml`**: revokes `Administrator` ACL on `/` (migration no-op if not set), then grants `range42-operator`.
- **`roles/proxmox.api-token/tasks/main.yml`**: imports `00_create_operator_role.yml` before `02_grant_acl.yml`.

## Migration path

Existing deployments: the revoke step removes the old `Administrator` grant automatically on next `02_configure_proxmox.yml` run. The `|| true` ensures this is a no-op on fresh installs where `Administrator` was never granted.

## Test plan

- [ ] Fresh install: `range42-operator` role created, ACL set — `Administrator` not in `pveum acl list /`
- [ ] Re-run: role and ACL steps are idempotent (`changed=false` on role, `changed=true` on ACL is expected)
- [ ] Migration: on existing deployment with `Administrator` grant — verify it is revoked and replaced
- [ ] API test passes with `range42-operator` privileges (GET `/api2/json/nodes`)