### PR TITLE
feat(proxmox.init,proxmox.api-token): scope SSH known_hosts per deployment

### DIFF
--- a/playbooks/02_configure_proxmox.yml
+++ b/playbooks/02_configure_proxmox.yml
@@ -15,6 +15,7 @@
 #   - jump_user exists on proxmox with SSH key access
 #   - API token is created and tested
 #   - locale is set to C.UTF-8
+#   - config/<codename>-<scenario>/known_hosts stores the Proxmox host fingerprint
 #
 ################################################################################
 
@@ -27,6 +28,10 @@
     DEPLOYER_CLI_ROOT_DIR: "{{ playbook_dir }}/.."
     proxmox_root_ssh_key_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root"
     proxmox_jump_ssh_key_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.jump_user"
+    proxmox_known_hosts_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/known_hosts"
+    proxmox_ssh_args: >-
+      -o UserKnownHostsFile={{ proxmox_known_hosts_path }}
+      -o StrictHostKeyChecking=yes
 
   # ensure ssh-agent is running for the entire play (all roles need it)
   # if agent is already running (keychain, etc.), reuse it

--- a/roles/proxmox.api-token/defaults/main.yml
+++ b/roles/proxmox.api-token/defaults/main.yml
@@ -12,3 +12,7 @@ proxmox_api_host: "{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:8006"
 proxmox_api_user: "range42_api@pam"
 proxmox_api_token_id: "r42_{{ INFRASTRUCTURE_CODENAME }}_{{ INFRASTRUCTURE_SCENARIO }}"
 proxmox_api_token_secret: ""
+
+# SSH -o options injected into all ssh commands targeting Proxmox
+# set by 02_configure_proxmox.yml; empty string = system defaults (backward-compat)
+proxmox_ssh_args: ""

--- a/roles/proxmox.api-token/tasks/00_create_api_user.yml
+++ b/roles/proxmox.api-token/tasks/00_create_api_user.yml
@@ -12,7 +12,7 @@
 
 - name: PROXMOX API-TOKEN - CREATE PVE USER (SKIP IF EXISTS)
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pveum user add {{ proxmox_api_user }} 2>&1 || true"
   register: pve_user_create
   changed_when: "'already exists' not in pve_user_create.stdout"

--- a/roles/proxmox.api-token/tasks/01_create_or_import_token.yml
+++ b/roles/proxmox.api-token/tasks/01_create_or_import_token.yml
@@ -10,7 +10,7 @@
 
 - name: PROXMOX API-TOKEN - TRY TO CREATE TOKEN ON PROXMOX
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pveum user token add {{ proxmox_api_user }} {{ proxmox_api_token_id }}
     --privsep 0 --output-format json 2>&1"
   register: token_create_raw
@@ -47,7 +47,7 @@
 
 - name: PROXMOX API-TOKEN - AUTO-RECOVERY — DELETE TOKEN (NO SECRET AVAILABLE)
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pveum user token remove {{ proxmox_api_user }} {{ proxmox_api_token_id }} 2>&1 || true"
   when:
     - token_already_existed | bool
@@ -56,7 +56,7 @@
 
 - name: PROXMOX API-TOKEN - AUTO-RECOVERY — RECREATE TOKEN
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pveum user token add {{ proxmox_api_user }} {{ proxmox_api_token_id }}
     --privsep 0 --output-format json 2>&1"
   register: token_recreate_raw

--- a/roles/proxmox.api-token/tasks/02_grant_acl.yml
+++ b/roles/proxmox.api-token/tasks/02_grant_acl.yml
@@ -5,6 +5,6 @@
 
 - name: PROXMOX API-TOKEN - GRANT ADMINISTRATOR ROLE ON /
   ansible.builtin.command: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     pveum acl modify / -user {{ proxmox_api_user }} -role Administrator
   changed_when: true

--- a/roles/proxmox.init/defaults/main.yml
+++ b/roles/proxmox.init/defaults/main.yml
@@ -13,6 +13,14 @@ proxmox_root_ssh_key_path: "to_define"
 # locale to set on proxmox
 proxmox_locale: "C.UTF-8"
 
+# per-deployment known_hosts file — populated by 00_scan_host_fingerprint
+# typically: ./config/CODENAME-SCENARIO/known_hosts (gitignored via config/*/)
+proxmox_known_hosts_path: "to_define"
+
+# SSH -o options injected into all ssh/scp commands targeting Proxmox
+# set by 02_configure_proxmox.yml; empty string = system defaults (backward-compat)
+proxmox_ssh_args: ""
+
 # network bridge for lab VMs
 vm_net_virtio_bridge: "vmbr142"
 

--- a/roles/proxmox.init/tasks/00_scan_host_fingerprint.yml
+++ b/roles/proxmox.init/tasks/00_scan_host_fingerprint.yml
@@ -1,0 +1,42 @@
+---
+# proxmox.init - capture Proxmox SSH fingerprint into per-deployment known_hosts
+#
+# On first run: ssh-keyscan collects all host keys from INFRASTRUCTURE_PROXMOX_ADDRESS
+# and writes them to config/<codename>-<scenario>/known_hosts (gitignored via config/*/).
+# force: false preserves the file on subsequent runs so the stored key acts as the
+# trust anchor — ssh errors loudly if the key changes unexpectedly.
+
+- name: PROXMOX INIT - SCAN PROXMOX HOST KEYS
+  ansible.builtin.shell: >
+    ssh-keyscan -H {{ INFRASTRUCTURE_PROXMOX_ADDRESS }} 2>/dev/null
+  register: _ssh_keyscan
+  changed_when: false
+  failed_when: _ssh_keyscan.stdout | length == 0
+
+- name: PROXMOX INIT - WRITE KNOWN_HOSTS (FIRST RUN ONLY — NOT OVERWRITTEN)
+  ansible.builtin.copy:
+    content: "{{ _ssh_keyscan.stdout }}\n"
+    dest: "{{ proxmox_known_hosts_path }}"
+    mode: "0600"
+    force: false
+
+- name: PROXMOX INIT - COMPUTE FINGERPRINT FOR DISPLAY
+  ansible.builtin.shell: >
+    ssh-keygen -l -f {{ proxmox_known_hosts_path }}
+  register: _fingerprint
+  changed_when: false
+  failed_when: false
+
+- name: PROXMOX INIT - SHOW KNOWN_HOSTS FINGERPRINT
+  ansible.builtin.debug:
+    msg: |
+
+      #### #### #### #### #### #### #### #### #### #### ####
+      Proxmox SSH fingerprint — verify on first setup:
+
+      {{ _fingerprint.stdout | default('(could not compute fingerprint)') }}
+
+      To verify on Proxmox:
+        ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} \
+          'ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub'
+      #### #### #### #### #### #### #### #### #### #### ####

--- a/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
+++ b/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
@@ -8,7 +8,7 @@
 
 - name: PROXMOX INIT - TEST IF ROOT KEY AUTH ALREADY WORKS
   ansible.builtin.command: >
-    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    ssh {{ proxmox_ssh_args | default('') }} -o BatchMode=yes
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   register: root_ssh_test
   changed_when: false
@@ -36,7 +36,7 @@
 - name: PROXMOX INIT - INSTALL ROOT PUBLIC KEY VIA SSHPASS + SSH-COPY-ID
   ansible.builtin.shell: >
     sshpass -e ssh-copy-id
-    -o StrictHostKeyChecking=accept-new
+    {{ proxmox_ssh_args | default('') }}
     -o IdentitiesOnly=yes
     -i "{{ proxmox_root_ssh_key_path }}.pub"
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
@@ -52,7 +52,7 @@
 - name: PROXMOX INIT - INSTALL ROOT PUBLIC KEY VIA SSH-COPY-ID (INTERACTIVE FALLBACK)
   ansible.builtin.command: >
     ssh-copy-id
-    -o StrictHostKeyChecking=accept-new
+    {{ proxmox_ssh_args | default('') }}
     -o IdentitiesOnly=yes
     -o PreferredAuthentications=password
     -i "{{ proxmox_root_ssh_key_path }}.pub"
@@ -65,7 +65,7 @@
 
 - name: PROXMOX INIT - VERIFY ROOT KEY AUTH WORKS AFTER INSTALL
   ansible.builtin.command: >
-    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    ssh {{ proxmox_ssh_args | default('') }} -o BatchMode=yes
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   when: root_ssh_test.rc != 0
   changed_when: false

--- a/roles/proxmox.init/tasks/02_fix_remote_locale.yml
+++ b/roles/proxmox.init/tasks/02_fix_remote_locale.yml
@@ -9,7 +9,7 @@
 
 - name: PROXMOX INIT - SET /ETC/DEFAULT/LOCALE TO {{ proxmox_locale }}
   ansible.builtin.shell: |
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} 'bash -c "
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} 'bash -c "
       echo \"LANG={{ proxmox_locale }}\" > /etc/default/locale
       echo \"LC_ALL={{ proxmox_locale }}\" >> /etc/default/locale
       echo \"LANGUAGE={{ proxmox_locale }}\" >> /etc/default/locale
@@ -17,12 +17,12 @@
 
 - name: PROXMOX INIT - RUN LOCALE-GEN {{ proxmox_locale }}
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "locale-gen {{ proxmox_locale }} 2>/dev/null || true"
   changed_when: true
 
 - name: PROXMOX INIT - EXPORT LOCALE IN REMOTE SESSION
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "export LANG={{ proxmox_locale }} LC_ALL={{ proxmox_locale }} LANGUAGE={{ proxmox_locale }}"
   changed_when: false

--- a/roles/proxmox.init/tasks/03_create_network_bridge.yml
+++ b/roles/proxmox.init/tasks/03_create_network_bridge.yml
@@ -8,7 +8,7 @@
 
 - name: PROXMOX INIT - CHECK EXISTING BRIDGES
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pvesh get /nodes/{{ proxmox_node }}/network --type bridge 2>/dev/null | grep -oP 'vmbr1[45]\d' | sort -u || true"
   register: existing_bridges
   changed_when: false
@@ -17,7 +17,7 @@
 
 - name: PROXMOX INIT - CREATE LAB BRIDGES
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pvesh create /nodes/{{ proxmox_node }}/network
     --iface {{ item.name }}
     --type bridge
@@ -31,7 +31,7 @@
 
 - name: PROXMOX INIT - APPLY NETWORK CONFIGURATION
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "pvesh set /nodes/{{ proxmox_node }}/network"
   when: bridges_created.changed | default(false)
 
@@ -39,9 +39,9 @@
 
 - name: PROXMOX INIT - UPLOAD NAT INJECT SCRIPT
   ansible.builtin.shell: >
-    scp {{ role_path }}/files/inject_nat_rules.sh
+    scp {{ proxmox_ssh_args | default('') }} {{ role_path }}/files/inject_nat_rules.sh
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:/tmp/inject_nat_rules.sh &&
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} "chmod +x /tmp/inject_nat_rules.sh"
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} "chmod +x /tmp/inject_nat_rules.sh"
 
 - name: PROXMOX INIT - RENDER NAT RULES FOR ENABLED BRIDGES
   ansible.builtin.template:
@@ -54,15 +54,15 @@
 
 - name: PROXMOX INIT - UPLOAD AND INJECT NAT (ENABLED BRIDGES)
   ansible.builtin.shell: >
-    scp /tmp/range42_nat_{{ item.name }}.txt
+    scp {{ proxmox_ssh_args | default('') }} /tmp/range42_nat_{{ item.name }}.txt
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:/tmp/range42_nat_{{ item.name }}.txt &&
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "/tmp/inject_nat_rules.sh {{ item.name }} /tmp/range42_nat_{{ item.name }}.txt"
   loop: "{{ range42_lab_bridges | selectattr('nat') | list }}"
 
 - name: PROXMOX INIT - REMOVE NAT (DISABLED BRIDGES)
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "/tmp/inject_nat_rules.sh {{ item.name }} REMOVE"
   loop: "{{ range42_lab_bridges | rejectattr('nat') | list }}"
 
@@ -74,14 +74,14 @@
 
 - name: PROXMOX INIT - CLEAN UP REMOTE INJECT SCRIPT
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "rm -f /tmp/inject_nat_rules.sh"
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
 - name: PROXMOX INIT - ENABLE IP FORWARDING
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "echo 1 > /proc/sys/net/ipv4/ip_forward &&
     (grep -q '^net.ipv4.ip_forward' /etc/sysctl.conf &&
     sed -i 's/^#*net.ipv4.ip_forward=.*/net.ipv4.ip_forward=1/' /etc/sysctl.conf ||
@@ -92,7 +92,7 @@
 
 - name: PROXMOX INIT - RELOAD NETWORK
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "ifreload -a 2>/dev/null || true"
   changed_when: false
 

--- a/roles/proxmox.init/tasks/04_apt_proxy_snippet.yml
+++ b/roles/proxmox.init/tasks/04_apt_proxy_snippet.yml
@@ -15,7 +15,7 @@
 
 - name: PROXMOX INIT - ENSURE SNIPPETS DIR EXISTS ON PROXMOX
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "mkdir -p /var/lib/vz/snippets"
   when: apt_proxy_url is defined and (apt_proxy_url | length) > 0
   changed_when: false
@@ -33,9 +33,9 @@
 
 - name: PROXMOX INIT - UPLOAD APT PROXY SNIPPET TO PROXMOX
   ansible.builtin.shell: >
-    scp /tmp/range42-apt-proxy.yaml
+    scp {{ proxmox_ssh_args | default('') }} /tmp/range42-apt-proxy.yaml
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:/var/lib/vz/snippets/range42-apt-proxy.yaml &&
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "chmod 644 /var/lib/vz/snippets/range42-apt-proxy.yaml"
   when: apt_proxy_url is defined and (apt_proxy_url | length) > 0
 
@@ -47,7 +47,7 @@
 
 - name: PROXMOX INIT - REMOVE APT PROXY SNIPPET ON PROXMOX (apt_proxy_url unset)
   ansible.builtin.shell: >
-    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    ssh {{ proxmox_ssh_args | default('') }} root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
     "rm -f /var/lib/vz/snippets/range42-apt-proxy.yaml"
   when: apt_proxy_url is not defined or (apt_proxy_url | length) == 0
   changed_when: false

--- a/roles/proxmox.init/tasks/main.yml
+++ b/roles/proxmox.init/tasks/main.yml
@@ -14,22 +14,27 @@
 # What this role does:
 #   1. Ensure ssh-agent is running
 #   2. Load the Proxmox root SSH key into the agent
-#   3. Install the public key on the Proxmox server (ssh-copy-id if needed)
-#   4. Fix locale on Proxmox (set C.UTF-8 in /etc/default/locale + locale-gen)
+#   3. Scan and store the Proxmox host fingerprint (per-deployment known_hosts)
+#   4. Install the public key on the Proxmox server (ssh-copy-id if needed)
+#   5. Fix locale on Proxmox (set C.UTF-8 in /etc/default/locale + locale-gen)
 #
 # Variables consumed:
 #   - INFRASTRUCTURE_PROXMOX_ADDRESS   (required — FQDN or IP of the Proxmox host)
 #   - proxmox_root_ssh_key_path        (required — path to the generated root SSH key)
+#   - proxmox_known_hosts_path         (required — local path to write the known_hosts)
+#   - proxmox_ssh_args                 (optional — extra SSH -o options for all commands)
 #
 # After this role:
 #   - root@PROXMOX_ADDRESS is reachable via SSH key (no password)
 #   - locale is set to C.UTF-8
+#   - config/<codename>-<scenario>/known_hosts contains the Proxmox host fingerprint
 #   - proxmox.jump-user and proxmox.api-token can run
 #
 ################################################################################
 
 - import_tasks: ./00_load_root_ssh_key.yml
+- import_tasks: ./00_scan_host_fingerprint.yml      # capture host fingerprint before first SSH
 - import_tasks: ./01_install_root_pubkey_on_proxmox.yml
 - import_tasks: ./02_fix_remote_locale.yml
 - import_tasks: ./03_create_network_bridge.yml
-- import_tasks: ./04_apt_proxy_snippet.yml      # cloud-init cicustom snippet (no-op if apt_proxy_url empty)
+- import_tasks: ./04_apt_proxy_snippet.yml          # cloud-init cicustom snippet (no-op if apt_proxy_url empty)


### PR DESCRIPTION
Closes #90

## Summary

- **`roles/proxmox.init/tasks/00_scan_host_fingerprint.yml`** (new): uses `ssh-keyscan -H` to capture all Proxmox host keys into `config/<codename>-<scenario>/known_hosts` on first run (`force: false` preserves on subsequent runs). Displays the fingerprint so operators can verify on first setup.
- **All `ssh`/`scp` commands** in `proxmox.init` and `proxmox.api-token` tasks now include `{{ proxmox_ssh_args | default('') }}` — uses the scoped `known_hosts` with `StrictHostKeyChecking=yes` instead of the global `accept-new`.
- **`playbooks/02_configure_proxmox.yml`**: adds `proxmox_known_hosts_path` and `proxmox_ssh_args` vars.
- **`roles/proxmox.init/defaults/main.yml`**: adds `proxmox_known_hosts_path` and `proxmox_ssh_args` stubs.
- **`roles/proxmox.api-token/defaults/main.yml`**: adds `proxmox_ssh_args: ""` stub (empty = system defaults, backward-compatible).

## Security behaviour

| Run | Behaviour |
|-----|-----------|
| First | `ssh-keyscan` collects keys → writes `known_hosts` → shows fingerprint for verification |
| Subsequent | `known_hosts` preserved (`force: false`) → `StrictHostKeyChecking=yes` detects key changes |
| Key change | `ssh` errors loudly — operator deletes `known_hosts` and re-verifies |

## Note on conflicts

This PR modifies `02_grant_acl.yml` to add `{{ proxmox_ssh_args }}` to the existing `Administrator` grant. If PR #127 (least-privilege role) merges first, that file will need a trivial rebase to combine both changes.

## Test plan

- [ ] First run: `config/<codename>-<scenario>/known_hosts` created, fingerprint displayed
- [ ] Re-run: `known_hosts` not overwritten (idempotent)
- [ ] SSH to Proxmox succeeds with `StrictHostKeyChecking=yes`
- [ ] Key mismatch: manually corrupt `known_hosts` — playbook fails with a clear SSH error
- [ ] `proxmox_ssh_args` empty (standalone role): all tasks fall back to system SSH defaults