### PR TITLE
feat(credentials): add 04_rotate_credentials playbook with Proxmox key revocation

### DIFF
--- a/playbooks/04_rotate_credentials.yml
+++ b/playbooks/04_rotate_credentials.yml
@@ -1,0 +1,194 @@
+---
+################################################################################
+# 04 — Rotate credentials (SSH keys, passwords, vault)
+#
+# DESTRUCTIVE OPERATION — requires explicit confirmation.
+#
+# Revokes existing SSH keys on Proxmox, regenerates all credentials,
+# re-encrypts the vault, and installs new keys on Proxmox.
+#
+# Usage:
+#   ansible-playbook playbooks/04_rotate_credentials.yml \
+#     -i inventories/<codename>/hosts.yml \
+#     -e INFRASTRUCTURE_SCENARIO=demo_lab \
+#     -e ROTATE_KEYS_CONFIRM=YES
+#
+# Requires:
+#   - 02_configure_proxmox.yml previously completed (root SSH key exists on disk)
+#   - Old root SSH key loadable (passphrase will be prompted if not in agent)
+#
+# After this playbook:
+#   - New SSH keys in config/<codename>-<scenario>/ssh_keys/
+#   - Vault re-encrypted with new public key content
+#   - Old authorized_keys entries revoked on Proxmox
+#   - New authorized_keys entries installed on Proxmox
+#   - Run 03_deploy_deployer_cli.yml to push new keys to deployer-cli
+#
+################################################################################
+
+- name: 04 rotate credentials - revoke old keys and regenerate
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    DEPLOYER_CLI_ROOT_DIR: "{{ playbook_dir }}/.."
+    credentials_output_dir: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
+    vault_output_dir: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/secrets"
+    proxmox_root_ssh_key_path: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root"
+    proxmox_jump_ssh_key_path: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.jump_user"
+    credentials_force_regenerate: true
+
+  pre_tasks:
+    - name: ROTATE CREDENTIALS - GUARD AGAINST ACCIDENTAL RUN
+      ansible.builtin.fail:
+        msg: |
+
+          #### #### #### #### #### #### #### #### #### #### ####
+          ROTATE CREDENTIALS: explicit confirmation required.
+
+          This playbook will:
+            - Revoke all current SSH keys on Proxmox
+            - Regenerate SSH keys and VM passwords
+            - Re-encrypt the vault with new key content
+            - Install new keys on Proxmox
+
+          Scope: {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}
+
+          To confirm, re-run with: -e ROTATE_KEYS_CONFIRM=YES
+          #### #### #### #### #### #### #### #### #### #### ####
+      when: ROTATE_KEYS_CONFIRM | default('') | upper != 'YES'
+
+    - name: ROTATE CREDENTIALS - VERIFY OLD ROOT KEY EXISTS ON DISK
+      ansible.builtin.stat:
+        path: "{{ proxmox_root_ssh_key_path }}"
+      register: _old_root_key_stat
+      failed_when: not _old_root_key_stat.stat.exists
+
+    - name: ROTATE CREDENTIALS - READ OLD ROOT PUBLIC KEY
+      ansible.builtin.slurp:
+        src: "{{ proxmox_root_ssh_key_path }}.pub"
+      register: _old_root_pubkey_raw
+
+    - name: ROTATE CREDENTIALS - READ OLD JUMP PUBLIC KEY
+      ansible.builtin.slurp:
+        src: "{{ proxmox_jump_ssh_key_path }}.pub"
+      register: _old_jump_pubkey_raw
+
+    - name: ROTATE CREDENTIALS - SAVE OLD PUBLIC KEYS AS FACTS
+      ansible.builtin.set_fact:
+        old_root_pubkey: "{{ _old_root_pubkey_raw.content | b64decode | trim }}"
+        old_jump_pubkey: "{{ _old_jump_pubkey_raw.content | b64decode | trim }}"
+
+    # Load the old root key into the agent now, before credentials.generate
+    # overwrites the key files. The in-memory agent key survives the file
+    # overwrite and is used in post_tasks to access Proxmox.
+    - name: ROTATE CREDENTIALS - CHECK SSH-AGENT IS RUNNING
+      ansible.builtin.command: ssh-add -l
+      register: _agent_check
+      changed_when: false
+      failed_when: false
+
+    - name: ROTATE CREDENTIALS - START SSH-AGENT IF NEEDED
+      ansible.builtin.shell: |
+        ssh-agent -s | head -2
+      register: _agent_start
+      when: _agent_check.rc == 2
+
+    - name: ROTATE CREDENTIALS - SET SSH_AUTH_SOCK FACT (NEW AGENT)
+      ansible.builtin.set_fact:
+        _ssh_auth_sock: "{{ _agent_start.stdout | regex_search('SSH_AUTH_SOCK=([^;]+)', '\\1') | first }}"
+      when: _agent_check.rc == 2
+
+    - name: ROTATE CREDENTIALS - SET SSH_AUTH_SOCK FACT (EXISTING AGENT)
+      ansible.builtin.set_fact:
+        _ssh_auth_sock: "{{ lookup('env', 'SSH_AUTH_SOCK') }}"
+      when: _agent_check.rc != 2
+
+    - name: ROTATE CREDENTIALS - LOAD OLD ROOT KEY INTO AGENT
+      ansible.builtin.command: ssh-add "{{ proxmox_root_ssh_key_path }}"
+      register: _agent_load
+      changed_when: "'Identity added' in (_agent_load.stderr | default(''))"
+      failed_when: false
+
+  environment:
+    SSH_AUTH_SOCK: "{{ _ssh_auth_sock | default(lookup('env', 'SSH_AUTH_SOCK')) }}"
+
+  roles:
+    - credentials.generate   # credentials_force_regenerate=true overwrites existing keys
+    - credentials.vault      # re-encrypts vault with new public key content
+
+  post_tasks:
+    - name: ROTATE CREDENTIALS - READ NEW ROOT PUBLIC KEY
+      ansible.builtin.slurp:
+        src: "{{ proxmox_root_ssh_key_path }}.pub"
+      register: _new_root_pubkey_raw
+
+    - name: ROTATE CREDENTIALS - READ NEW JUMP PUBLIC KEY
+      ansible.builtin.slurp:
+        src: "{{ proxmox_jump_ssh_key_path }}.pub"
+      register: _new_jump_pubkey_raw
+
+    - name: ROTATE CREDENTIALS - SET NEW PUBLIC KEY FACTS
+      ansible.builtin.set_fact:
+        new_root_pubkey: "{{ _new_root_pubkey_raw.content | b64decode | trim }}"
+        new_jump_pubkey: "{{ _new_jump_pubkey_raw.content | b64decode | trim }}"
+
+    - name: ROTATE CREDENTIALS - REVOKE OLD ROOT KEY ON PROXMOX
+      ansible.builtin.shell: >
+        ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+        "grep -vxF '{{ old_root_pubkey }}'
+        /root/.ssh/authorized_keys > /tmp/.ak_r42 2>/dev/null &&
+        mv /tmp/.ak_r42 /root/.ssh/authorized_keys || true"
+
+    - name: ROTATE CREDENTIALS - INSTALL NEW ROOT KEY ON PROXMOX
+      ansible.builtin.shell: >
+        ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+        "grep -qxF '{{ new_root_pubkey }}'
+        /root/.ssh/authorized_keys 2>/dev/null ||
+        echo '{{ new_root_pubkey }}'
+        >> /root/.ssh/authorized_keys"
+
+    - name: ROTATE CREDENTIALS - REVOKE OLD JUMP KEY ON PROXMOX
+      ansible.builtin.shell: >
+        ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+        "grep -vxF '{{ old_jump_pubkey }}'
+        /home/{{ jump_user }}/.ssh/authorized_keys > /tmp/.jk_r42 2>/dev/null &&
+        mv /tmp/.jk_r42 /home/{{ jump_user }}/.ssh/authorized_keys || true"
+      when: jump_on_proxmox | default('YES') | upper == 'YES'
+
+    - name: ROTATE CREDENTIALS - INSTALL NEW JUMP KEY ON PROXMOX
+      ansible.builtin.shell: >
+        ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+        "grep -qxF '{{ new_jump_pubkey }}'
+        /home/{{ jump_user }}/.ssh/authorized_keys 2>/dev/null ||
+        echo '{{ new_jump_pubkey }}'
+        >> /home/{{ jump_user }}/.ssh/authorized_keys"
+      when: jump_on_proxmox | default('YES') | upper == 'YES'
+
+    - name: ROTATE CREDENTIALS - DISPLAY POST-ROTATION INSTRUCTIONS
+      ansible.builtin.debug:
+        msg: |
+
+          #### #### #### #### #### #### #### #### #### #### ####
+          CREDENTIAL ROTATION COMPLETE
+
+          New SSH keys generated, vault re-encrypted,
+          Proxmox authorized_keys updated.
+
+          NEXT STEPS:
+
+          1. Redeploy new keys to deployer-cli:
+
+               ansible-playbook playbooks/03_deploy_deployer_cli.yml \
+                 -i inventories/{{ INFRASTRUCTURE_CODENAME }}/hosts.yml \
+                 -e INFRASTRUCTURE_SCENARIO={{ INFRASTRUCTURE_SCENARIO }} \
+                 --vault-password-file \
+                   config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/secrets/vault_pass.txt
+
+          2. Update ssh-agent on deployer-cli with new passphrases:
+               cat config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/passwords.env
+
+          3. Verify access:
+               ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
+          #### #### #### #### #### #### #### #### #### #### ####

--- a/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
+++ b/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
@@ -3,6 +3,7 @@
 #
 # key type: ed25519 (matches original ssh-keygen -t ed25519)
 # idempotent: community.crypto.openssh_keypair skips if key already exists
+# rotation: set credentials_force_regenerate=true to overwrite existing keys
 #
 # if context_ssh_keys_use_passphrase == NO : keys are created without passphrase
 # if context_auto_generate_ssh_keys == NO  : keys must already exist at expected paths
@@ -47,6 +48,7 @@
     comment: "proxmox root {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_root_passphrase | default(omit, true) }}"
     mode: "0600"
+    force: "{{ credentials_force_regenerate | default(false) }}"
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_root
 
@@ -57,6 +59,7 @@
     comment: "proxmox jump {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_jump_passphrase | default(omit, true) }}"
     mode: "0600"
+    force: "{{ credentials_force_regenerate | default(false) }}"
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_jump
 
@@ -67,6 +70,7 @@
     comment: "r42 deployer (admin) - alice {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_deployer_passphrase | default(omit, true) }}"
     mode: "0600"
+    force: "{{ credentials_force_regenerate | default(false) }}"
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_alice
 
@@ -77,6 +81,7 @@
     comment: "r42 student (user) - bob {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_student_passphrase | default(omit, true) }}"
     mode: "0600"
+    force: "{{ credentials_force_regenerate | default(false) }}"
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_bob
 


### PR DESCRIPTION
Closes #95

## Summary

- **`playbooks/04_rotate_credentials.yml`** (new): deliberate key rotation playbook requiring `-e ROTATE_KEYS_CONFIRM=YES` to run. Flow:
  1. Reads old root and jump public keys from disk into facts (before overwrite)
  2. Loads old root key into ssh-agent so it survives file overwrite
  3. Runs `credentials.generate` with `credentials_force_regenerate=true` (overwrites all keys + regenerates passphrases)
  4. Runs `credentials.vault` to re-encrypt vault with new public key content
  5. Revokes old root/jump public keys from Proxmox `authorized_keys` via `grep -vxF`
  6. Installs new root/jump public keys on Proxmox
  7. Displays `03_deploy_deployer_cli.yml` instructions for pushing new keys to deployer-cli

- **`roles/credentials.generate/tasks/02_generate_ssh_keys.yml`**: adds `force: "{{ credentials_force_regenerate | default(false) }}"` to all four `openssh_keypair` tasks. Normal runs (`01_generate_credentials.yml`) are unaffected — `force` defaults to `false`.

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Separate `04_rotate_credentials.yml` playbook | Deliberate operator action, not mixed into the normal `01_generate_credentials.yml` flow |
| `ROTATE_KEYS_CONFIRM=YES` guard | Prevents accidental key rotation |
| ssh-agent approach for old key retention | Old key loaded into agent memory before files are overwritten; in-memory key remains valid for Proxmox SSH in post_tasks |
| `grep -vxF` for revocation | Exact-line, fixed-string match — safe for ed25519 key content, no regex escaping needed |
| First-run safety | `stat` pre-task fails cleanly if no prior credentials exist |

## Requirements

- `02_configure_proxmox.yml` must have been run before (root SSH key exists on disk)
- Old root key passphrase will be prompted via `ssh-add` if not already in the agent

## Test plan

- [ ] No prior credentials: playbook fails with a clear error before any destructive action
- [ ] Missing `ROTATE_KEYS_CONFIRM`: playbook fails with the confirmation message
- [ ] Normal run (`01_generate_credentials.yml`): `force=false` — existing keys untouched
- [ ] Rotation run: new key files generated, old keys revoked on Proxmox, new keys installed
- [ ] After rotation: `ssh root@<proxmox> true` works with new key; old key rejected
- [ ] After `03_deploy_deployer_cli.yml`: deployer-cli has new keys