### PR TITLE
fix(proxmox.init): preflight check for ISO-capable storage before deployment

### DIFF
--- a/roles/proxmox.init/tasks/05_check_iso_storage.yml
+++ b/roles/proxmox.init/tasks/05_check_iso_storage.yml
@@ -1,0 +1,33 @@
+---
+# proxmox init - preflight: verify at least one storage supports ISO content type
+#
+# runs after SSH key auth is confirmed, before any ISO download is attempted
+# fails early with a clear message if no ISO-capable storage exists
+
+- name: PROXMOX INIT - CHECK ISO-CAPABLE STORAGE
+  ansible.builtin.shell: >
+    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    "pvesm status --content iso 2>/dev/null | awk 'NR>1 && $3==\"active\" {print $1}'"
+  register: iso_storages
+  changed_when: false
+
+- name: PROXMOX INIT - FAIL IF NO ISO-CAPABLE STORAGE FOUND
+  ansible.builtin.fail:
+    msg: |
+
+      #### #### #### #### #### #### #### #### #### #### ####
+
+      PREFLIGHT FAILED: No Proxmox storage configured for ISO images
+
+      The deployer needs at least one active storage with ISO content
+      type enabled to download VM templates.
+
+      To fix this, in the Proxmox web UI:
+        Datacenter → Storage → select a storage → Edit
+        → enable "ISO Image" under Allowed Content
+
+      Or via CLI on the Proxmox host:
+        pvesm set local --content backup,iso,snippets,vztmpl
+
+      #### #### #### #### #### #### #### #### #### #### ####
+  when: iso_storages.stdout | trim | length == 0

--- a/roles/proxmox.init/tasks/main.yml
+++ b/roles/proxmox.init/tasks/main.yml
@@ -33,3 +33,4 @@
 - import_tasks: ./02_fix_remote_locale.yml
 - import_tasks: ./03_create_network_bridge.yml
 - import_tasks: ./04_apt_proxy_snippet.yml      # cloud-init cicustom snippet (no-op if apt_proxy_url empty)
+- import_tasks: ./05_check_iso_storage.yml     # preflight: fail early if no storage supports ISO content type


### PR DESCRIPTION
## Summary

Closes #21

- Adds `roles/proxmox.init/tasks/05_check_iso_storage.yml` — runs an SSH command to `pvesm status --content iso` on the Proxmox host and collects any active ISO-capable storages
- Fails immediately with a human-readable remediation message if none are found, instead of letting the deployment run until the ISO download task hits an HTTP 500 mid-playbook
- Wired into `proxmox.init/tasks/main.yml` as the last import (after SSH key auth is confirmed)

## Test plan

- [ ] Run playbook 02 against a Proxmox where `local` storage has `iso` content type enabled → check passes, deployment continues normally
- [ ] Run playbook 02 against a Proxmox where no storage has `iso` content type → deployment fails at `PROXMOX INIT - FAIL IF NO ISO-CAPABLE STORAGE FOUND` with the remediation message
- [ ] Verify the `pvesm set local --content …` CLI hint in the error message resolves the issue and a re-run succeeds