### PR TITLE
fix(deployer.bootstrap): add rsync to base packages

### DIFF
--- a/roles/deployer.bootstrap/tasks/01_packages.yml
+++ b/roles/deployer.bootstrap/tasks/01_packages.yml
@@ -37,6 +37,7 @@
       - keychain
       - openssh-client
       - ca-certificates
+      - rsync
     state: present
   become: true
   when:
@@ -90,6 +91,7 @@
       - keychain
       - openssh-client
       - ca-certificates
+      - rsync
     state: present
   become: true
   when:


### PR DESCRIPTION
## Problem

`ansible.builtin.synchronize` (used by `software.install.nodejs_app_systemd`) delegates rsync execution to localhost — the deployer. rsync was never included in the deployer bootstrap package list, causing a missing executable error on first deploy of any scenario that includes the deployer-ui role.

## Fix

Added `rsync` to the base packages installed by `roles/deployer.bootstrap/tasks/01_packages.yml` for both Ubuntu and Debian.

Closes #145