### PR TITLE
fix(range42-context): ssh lookup searches included scenario SSH config files

### DIFF
--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -568,10 +568,21 @@ _r42_ssh() {
         return 1
     fi
 
-    # find matching host in active ssh config
+    # find matching host in main config + all included scenario configs
+    # (grep does not follow Include directives, so we expand them manually)
     local ssh_config="${HOME}/.ssh/config"
     local matches
-    matches=$(grep "^Host r42\." "$ssh_config" 2>/dev/null | awk '{print $2}' | grep -i "$pattern" | sort -u)
+    matches=$(
+        {
+            grep "^Host r42\." "$ssh_config" 2>/dev/null
+            grep '^Include ' "$ssh_config" 2>/dev/null \
+                | grep 'config_range42' \
+                | sed 's/^Include //' \
+                | while IFS= read -r inc; do
+                    grep "^Host r42\." "$inc" 2>/dev/null
+                done
+        } | awk '{print $2}' | grep -i "$pattern" | sort -u
+    )
 
     if [[ -z "$matches" ]]; then
         _r42_print_fail "no host matching '$pattern' found"


### PR DESCRIPTION
## Problem

`range42-context ssh <pattern>` was grepping only `~/.ssh/config` for `Host r42.*` entries. The actual host entries live in `~/.ssh/config_range42-<codename>-<scenario>`, referenced via `Include` — a directive `grep` does not follow.

Result: `range42-context ssh vuln-box-00` → `no host matching '...' found` even though the host was correctly defined.

## Fix

The `_r42_ssh` function now expands all `Include config_range42-*` lines from the main SSH config and searches those files too.

```
Before: range42-context ssh vuln-box-00  →  no host matching '...' found
After:  connects correctly
```

Closes #146