### PR TITLE
fix(proxmox.api-token): default validate_certs to false for self-signed certs

### DIFF
--- a/roles/proxmox.api-token/defaults/main.yml
+++ b/roles/proxmox.api-token/defaults/main.yml
@@ -12,3 +12,7 @@ proxmox_api_host: "{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}:8006"
 proxmox_api_user: "range42_api@pam"
 proxmox_api_token_id: "r42_{{ INFRASTRUCTURE_CODENAME }}_{{ INFRASTRUCTURE_SCENARIO }}"
 proxmox_api_token_secret: ""
+
+# proxmox ships with a self-signed certificate — set to true only if you have a valid CA-signed cert
+# override in inventories/<codename>/group_vars/all/vars.yml: proxmox_api_validate_certs: true
+proxmox_api_validate_certs: false


### PR DESCRIPTION
Split from #83. Proxmox ships with a self-signed cert — defaulting validate_certs to true breaks API token setup out of the box.

Closes #148