### PR TITLE
fix(ansible): hash jump-user password, pin known_hosts, idempotent ACL + apt

### DIFF
--- a/roles/deployer.bootstrap/tasks/01_packages.yml
+++ b/roles/deployer.bootstrap/tasks/01_packages.yml
@@ -69,10 +69,12 @@
     - ansible_facts['distribution'] == 'Ubuntu'
     - DEV_MODE_INSTALL_JUMP_HOST_ANSIBLE_PACKAGES | default('YES') | upper != 'NO'
 
-- name: DEPLOYER BOOTSTRAP - INSTALL ANSIBLE VIA RAW (UBUNTU)
-  ansible.builtin.raw: |
-    apt-get update -y
-    apt-get install -y python3 ansible
+- name: DEPLOYER BOOTSTRAP - INSTALL ANSIBLE AND PYTHON3 (UBUNTU)
+  ansible.builtin.apt:
+    name:
+      - python3
+      - ansible
+    state: present
   become: true
   when:
     - ansible_facts['distribution'] == 'Ubuntu'
@@ -122,10 +124,12 @@
     - ansible_facts['distribution'] == 'Debian'
     - DEV_MODE_INSTALL_JUMP_HOST_ANSIBLE_PACKAGES | default('YES') | upper != 'NO'
 
-- name: DEPLOYER BOOTSTRAP - INSTALL ANSIBLE VIA RAW (DEBIAN)
-  ansible.builtin.raw: |
-    apt-get update -y
-    apt-get install -y python3 ansible
+- name: DEPLOYER BOOTSTRAP - INSTALL ANSIBLE AND PYTHON3 (DEBIAN)
+  ansible.builtin.apt:
+    name:
+      - python3
+      - ansible
+    state: present
   become: true
   when:
     - ansible_facts['distribution'] == 'Debian'

--- a/roles/proxmox.api-token/tasks/02_grant_acl.yml
+++ b/roles/proxmox.api-token/tasks/02_grant_acl.yml
@@ -1,10 +1,22 @@
 ---
 # proxmox api-token - grant administrator acl on / for the api user
 #
+# Administrator on / gives full Proxmox API access — required for range42
+# to create and manage VMs, networks, and storage via the API.
+# Scope is intentionally / (root) to avoid per-datastore permission complexity.
+#
 # source: proxmox_generate_api_credentials() lines 1096-1097
+
+- name: PROXMOX API-TOKEN - CHECK EXISTING ACL FOR API USER
+  ansible.builtin.command: >
+    ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
+    "pveum acl list --path /"
+  register: _existing_acl
+  changed_when: false
 
 - name: PROXMOX API-TOKEN - GRANT ADMINISTRATOR ROLE ON /
   ansible.builtin.command: >
     ssh root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
-    pveum acl modify / -user {{ proxmox_api_user }} -role Administrator
-  changed_when: true
+    "pveum acl modify / -user {{ proxmox_api_user }} -role Administrator"
+  changed_when: proxmox_api_user not in _existing_acl.stdout
+  when: proxmox_api_user not in _existing_acl.stdout

--- a/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
+++ b/roles/proxmox.init/tasks/01_install_root_pubkey_on_proxmox.yml
@@ -9,6 +9,7 @@
 - name: PROXMOX INIT - TEST IF ROOT KEY AUTH ALREADY WORKS
   ansible.builtin.command: >
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile=/tmp/range42_known_hosts_{{ INFRASTRUCTURE_CODENAME | default('unknown') }}
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   register: root_ssh_test
   changed_when: false
@@ -37,6 +38,7 @@
   ansible.builtin.shell: >
     sshpass -e ssh-copy-id
     -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile=/tmp/range42_known_hosts_{{ INFRASTRUCTURE_CODENAME | default('unknown') }}
     -o IdentitiesOnly=yes
     -i "{{ proxmox_root_ssh_key_path }}.pub"
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}
@@ -53,6 +55,7 @@
   ansible.builtin.command: >
     ssh-copy-id
     -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile=/tmp/range42_known_hosts_{{ INFRASTRUCTURE_CODENAME | default('unknown') }}
     -o IdentitiesOnly=yes
     -o PreferredAuthentications=password
     -i "{{ proxmox_root_ssh_key_path }}.pub"
@@ -66,6 +69,7 @@
 - name: PROXMOX INIT - VERIFY ROOT KEY AUTH WORKS AFTER INSTALL
   ansible.builtin.command: >
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile=/tmp/range42_known_hosts_{{ INFRASTRUCTURE_CODENAME | default('unknown') }}
     root@{{ INFRASTRUCTURE_PROXMOX_ADDRESS }} true
   when: root_ssh_test.rc != 0
   changed_when: false

--- a/roles/proxmox.jump-user/defaults/main.yml
+++ b/roles/proxmox.jump-user/defaults/main.yml
@@ -16,3 +16,7 @@ jump_port: "22"
 # path to the generated jump SSH key (from credentials.generate)
 # typically: ./config/CODENAME-SCENARIO/ssh_keys/jump_keys/px.CODENAME-SCENARIO-ssh_cli.jump_user
 proxmox_jump_ssh_key_path: "to_define"
+
+# per-codename known_hosts file for jump-host SSH key pinning
+# prevents keys from silently accumulating in ~/.ssh/known_hosts
+known_hosts_file: "/tmp/range42_known_hosts_{{ INFRASTRUCTURE_CODENAME | default('unknown') }}"

--- a/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
+++ b/roles/proxmox.jump-user/tasks/00_create_jump_user.yml
@@ -23,9 +23,25 @@
     - jump_on_proxmox | default('YES') | upper == 'YES'
     - jump_user_check.rc != 0
 
-- name: PROXMOX JUMP-USER - SET JUMP USER PASSWORD
-  ansible.builtin.shell: >
-    ssh root@{{ jump_host }}
-    "echo '{{ jump_user }}:{{ jump_password }}' | chpasswd"
+- name: PROXMOX JUMP-USER - HASH JUMP PASSWORD CLIENT-SIDE
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - passwd
+      - -6
+      - "{{ jump_password }}"
+  register: jump_password_hash
+  changed_when: false
+  no_log: true
   when: jump_on_proxmox | default('YES') | upper == 'YES'
+  delegate_to: localhost
+
+- name: PROXMOX JUMP-USER - SET JUMP USER PASSWORD (HASHED)
+  ansible.builtin.command: >
+    ssh root@{{ jump_host }}
+    "echo '{{ jump_user }}:{{ jump_password_hash.stdout }}' | chpasswd -e"
+  when:
+    - jump_on_proxmox | default('YES') | upper == 'YES'
+    - jump_password_hash is defined
+  changed_when: true
   no_log: true

--- a/roles/proxmox.jump-user/tasks/01_install_jump_pubkey.yml
+++ b/roles/proxmox.jump-user/tasks/01_install_jump_pubkey.yml
@@ -39,6 +39,7 @@
 - name: PROXMOX JUMP-USER - VERIFY JUMP USER SSH ACCESS WORKS
   ansible.builtin.command: >
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile={{ known_hosts_file }}
     -i {{ proxmox_jump_ssh_key_path }}
     {{ jump_user }}@{{ jump_host }} true
   changed_when: false


### PR DESCRIPTION
Split from #86. Hashes jump-user password, pins known_hosts entries, and makes ACL and apt tasks idempotent.

Closes #151