### PR TITLE
Feature/ssh auto unlock from vault with ssh passphrase and range42-context show commands

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -634,7 +634,7 @@ mylab-demo_lab
 Lists all hosts the active workspace will deploy:
 
 ```
-$ range42-context inventory
+$ range42-context show-inventory
 
 @all:
   |--@range42_infrastructure:

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -131,8 +131,9 @@ A zsh function available on the deployer-cli. Central tool for managing workspac
 
 | Command | What it does |
 |---------|-------------|
-| `range42-context inventory` | show the Ansible inventory tree |
-| `range42-context passwords` | show generated credentials (summary.txt) |
+| `range42-context show-vault` | show ansible vault contents (decrypted on the fly) |
+| `range42-context show-config` | show workspace orientation (paths + SSH hosts) |
+| `range42-context show-inventory` | show the Ansible inventory tree |
 | `range42-context ssh <pattern>` | quick SSH to a VM by partial name (e.g. `ssh wazuh`) |
 | `range42-context help` | show all commands |
 

--- a/playbooks/01_generate_credentials.yml
+++ b/playbooks/01_generate_credentials.yml
@@ -12,7 +12,7 @@
 # Produces:
 #   config/<CODENAME>-<SCENARIO>/ssh_keys/   (all SSH keys)
 #   config/<CODENAME>-<SCENARIO>/secrets/     (encrypted vault + vault_pass.txt)
-#   config/<CODENAME>-<SCENARIO>/passwords.env (plaintext reference)
+#   config/<CODENAME>-<SCENARIO>/summary.txt  (workspace orientation, non-secret)
 #
 ################################################################################
 

--- a/range42-init.py
+++ b/range42-init.py
@@ -422,8 +422,12 @@ def prefill(name):
     S.apt_mirror_prewarm    = ex_bool("apt_mirror_prewarm")
     S.apt_mirror_persistent = ex_bool("apt_mirror_persistent")
     S.apt_mirror_vm_ip      = ex("apt_mirror_vm_ip")
-    for d in (INVENTORIES / name / "group_vars").iterdir():
-        if d.name != "all": S.scenario = d.name; break
+    # --catalog-try forces S.scenario=catalog_try upstream (line ~349). Skip the
+    # group_vars scan in that mode, otherwise a previous scenario dir on the same
+    # codename (e.g. debug_scenario_b/) silently overrides catalog_try.
+    if not _CLI_ARGS.catalog_try:
+        for d in (INVENTORIES / name / "group_vars").iterdir():
+            if d.name != "all": S.scenario = d.name; break
 
 def sed_f(path, old, new):
     p = Path(path)

--- a/range42-init.py
+++ b/range42-init.py
@@ -1893,8 +1893,7 @@ def post_wizard():
         _print_cmd(f"ansible-playbook site.yml \\")
         _print_cmd(f"  -i inventories/{S.codename}/hosts.yml \\")
         _print_cmd(f"  -e @inventories/{S.codename}/group_vars/{S.scenario}/vars.yml \\")
-        _print_cmd(f"  -e INFRASTRUCTURE_SCENARIO={S.scenario} \\")
-        _print_cmd(f"  -e context_ssh_keys_use_passphrase=NO")
+        _print_cmd(f"  -e INFRASTRUCTURE_SCENARIO={S.scenario}")
         print()
         return
 
@@ -1949,7 +1948,6 @@ def post_wizard():
          "-i", f"inventories/{S.codename}/hosts.yml",
          "-e", f"@{scenario_vars_file}",
          "-e", f"INFRASTRUCTURE_SCENARIO={S.scenario}",
-         "-e", "context_ssh_keys_use_passphrase=NO",
          *extra],
         cwd=str(SCRIPT_DIR), env=env
     ).returncode
@@ -2028,8 +2026,7 @@ def post_wizard():
         _print_cmd(f"ansible-playbook site.yml \\")
         _print_cmd(f"  -i inventories/{S.codename}/hosts.yml \\")
         _print_cmd(f"  -e @inventories/{S.codename}/group_vars/{S.scenario}/vars.yml \\")
-        _print_cmd(f"  -e INFRASTRUCTURE_SCENARIO={S.scenario} \\")
-        _print_cmd(f"  -e context_ssh_keys_use_passphrase=NO")
+        _print_cmd(f"  -e INFRASTRUCTURE_SCENARIO={S.scenario}")
         print()
 
 

--- a/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
+++ b/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
@@ -47,6 +47,7 @@
     comment: "proxmox root {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_root_passphrase | default(omit, true) }}"
     mode: "0600"
+    regenerate: full_idempotence
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_root
 
@@ -57,6 +58,7 @@
     comment: "proxmox jump {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_jump_passphrase | default(omit, true) }}"
     mode: "0600"
+    regenerate: full_idempotence
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_jump
 
@@ -67,6 +69,7 @@
     comment: "r42 deployer (admin) - alice {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_deployer_passphrase | default(omit, true) }}"
     mode: "0600"
+    regenerate: full_idempotence
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_alice
 
@@ -77,6 +80,7 @@
     comment: "r42 student (user) - bob {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_student_passphrase | default(omit, true) }}"
     mode: "0600"
+    regenerate: full_idempotence
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_bob
 

--- a/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
+++ b/roles/credentials.generate/tasks/02_generate_ssh_keys.yml
@@ -47,7 +47,7 @@
     comment: "proxmox root {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_root_passphrase | default(omit, true) }}"
     mode: "0600"
-    regenerate: full_idempotence
+    regenerate: always
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_root
 
@@ -58,7 +58,7 @@
     comment: "proxmox jump {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_px_jump_passphrase | default(omit, true) }}"
     mode: "0600"
-    regenerate: full_idempotence
+    regenerate: always
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_px_jump
 
@@ -69,7 +69,7 @@
     comment: "r42 deployer (admin) - alice {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_deployer_passphrase | default(omit, true) }}"
     mode: "0600"
-    regenerate: full_idempotence
+    regenerate: always
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_alice
 
@@ -80,7 +80,7 @@
     comment: "r42 student (user) - bob {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ generated_student_passphrase | default(omit, true) }}"
     mode: "0600"
-    regenerate: full_idempotence
+    regenerate: always
   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
   register: ssh_key_bob
 

--- a/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
+++ b/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
@@ -22,7 +22,7 @@
     comment: "r42 student (user) - bob [extra {{ item }}] {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ (context_ssh_keys_use_passphrase | default('YES') | upper == 'YES') | ternary(generated_student_extra_passphrase, omit) }}"
     mode: "0600"
-    regenerate: full_idempotence
+    regenerate: always
   loop: "{{ range(1, student_additional_keys_count + 1) | list }}"
   when:
     - context_auto_generate_ssh_keys | default('YES') | upper == 'YES'

--- a/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
+++ b/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
@@ -7,8 +7,13 @@
   when:
     - context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
     - context_ssh_keys_use_passphrase | default('YES') | upper == 'YES'
-    - student_additionnal_keys_count | default(0) | int > 0
+    - student_additional_keys_count | default(0) | int > 0
   no_log: true
+
+- name: CREDENTIALS GENERATE - SET EMPTY STUDENT EXTRA PASSPHRASE (FALLBACK)
+  ansible.builtin.set_fact:
+    generated_student_extra_passphrase: ""
+  when: generated_student_extra_passphrase is not defined
 
 - name: CREDENTIALS GENERATE - GENERATE ADDITIONAL STUDENT SSH KEYS
   community.crypto.openssh_keypair:

--- a/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
+++ b/roles/credentials.generate/tasks/03_generate_student_extra_keys.yml
@@ -22,6 +22,7 @@
     comment: "r42 student (user) - bob [extra {{ item }}] {{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}"
     passphrase: "{{ (context_ssh_keys_use_passphrase | default('YES') | upper == 'YES') | ternary(generated_student_extra_passphrase, omit) }}"
     mode: "0600"
+    regenerate: full_idempotence
   loop: "{{ range(1, student_additional_keys_count + 1) | list }}"
   when:
     - context_auto_generate_ssh_keys | default('YES') | upper == 'YES'

--- a/roles/credentials.generate/tasks/04_write_passwords_env.yml
+++ b/roles/credentials.generate/tasks/04_write_passwords_env.yml
@@ -1,14 +1,13 @@
 ---
-# credentials generate - write passwords.env (plaintext reference file)
-#
-# this file is NOT committed — one-time reference for the operator
-# contains ssh key passphrases and vm user passwords
-#
-# source: prepare_environment_ssh_keys() lines 560-580
+# COMMENT BLOCK BEFORE CHORE-DELETE :
+# passwords.env generation removed - all secrets now live in the ansible vault.
+# View with `range42-context show-vault` (deployer-cli) or `ansible-vault view`.
+# Task body kept commented for short-term rollback ; delete entirely in a
+# follow-up chore.
 
-- name: CREDENTIALS GENERATE - WRITE PASSWORDS.ENV
-  ansible.builtin.template:
-    src: passwords.env.j2
-    dest: "{{ credentials_output_dir }}/passwords.env"
-    mode: "0600"
-  when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
+# - name: CREDENTIALS GENERATE - WRITE PASSWORDS.ENV
+#   ansible.builtin.template:
+#     src: passwords.env.j2
+#     dest: "{{ credentials_output_dir }}/passwords.env"
+#     mode: "0600"
+#   when: context_auto_generate_ssh_keys | default('YES') | upper == 'YES'

--- a/roles/credentials.generate/tasks/05_export_pubkeys_as_facts.yml
+++ b/roles/credentials.generate/tasks/05_export_pubkeys_as_facts.yml
@@ -2,7 +2,19 @@
 # credentials generate - export public keys as facts for credentials.vault
 #
 # the vault role needs the public keys to populate cloud-init variables
-# (default_admin_vm_ci_ssh_key, default_trainee_vm_ci_ssh_key)
+# (default_admin_vm_ci_ssh_key, default_trainee_vm_ci_ssh_key) and the
+# extended SSH KEY section listing all generated keys (px_root, px_jump,
+# alice, bob, bob_1..bob_N).
+
+- name: CREDENTIALS GENERATE - READ PX ROOT PUBLIC KEY
+  ansible.builtin.slurp:
+    src: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root.pub"
+  register: px_root_pubkey_raw
+
+- name: CREDENTIALS GENERATE - READ PX JUMP PUBLIC KEY
+  ansible.builtin.slurp:
+    src: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.jump_user.pub"
+  register: px_jump_pubkey_raw
 
 - name: CREDENTIALS GENERATE - READ ALICE PUBLIC KEY
   ansible.builtin.slurp:
@@ -14,7 +26,30 @@
     src: "{{ credentials_output_dir }}/ssh_keys/student_keys/r42.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-student-key_bob.pub"
   register: bob_pubkey_raw
 
+- name: CREDENTIALS GENERATE - READ BOB EXTRA PUBLIC KEYS (bob_1 .. bob_N)
+  ansible.builtin.slurp:
+    src: "{{ credentials_output_dir }}/ssh_keys/student_keys/additional.students/r42.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-student-key_bob_{{ item }}.pub"
+  register: bob_extra_pubkeys_raw
+  loop: "{{ range(1, (student_additional_keys_count | default(0) | int) + 1) | list }}"
+  when:
+    - context_auto_generate_ssh_keys | default('YES') | upper == 'YES'
+    - student_additional_keys_count | default(0) | int > 0
+
 - name: CREDENTIALS GENERATE - SET PUBLIC KEY FACTS FOR VAULT
   ansible.builtin.set_fact:
+    generated_px_root_pubkey: "{{ px_root_pubkey_raw.content | b64decode | trim }}"
+    generated_px_jump_pubkey: "{{ px_jump_pubkey_raw.content | b64decode | trim }}"
     generated_admin_ssh_pubkey: "{{ alice_pubkey_raw.content | b64decode | trim }}"
     generated_trainee_ssh_pubkey: "{{ bob_pubkey_raw.content | b64decode | trim }}"
+
+- name: CREDENTIALS GENERATE - SET BOB EXTRA PUBLIC KEYS LIST
+  ansible.builtin.set_fact:
+    generated_student_extra_pubkeys: "{{ bob_extra_pubkeys_raw.results | map(attribute='content') | map('b64decode') | map('trim') | list }}"
+  when:
+    - bob_extra_pubkeys_raw.results is defined
+    - bob_extra_pubkeys_raw.results | length > 0
+
+- name: CREDENTIALS GENERATE - SET EMPTY BOB EXTRA PUBLIC KEYS LIST (FALLBACK)
+  ansible.builtin.set_fact:
+    generated_student_extra_pubkeys: []
+  when: generated_student_extra_pubkeys is not defined

--- a/roles/credentials.generate/tasks/main.yml
+++ b/roles/credentials.generate/tasks/main.yml
@@ -20,8 +20,9 @@
 #   │       ├── r42.CODENAME-SCENARIO-student-key_bob (+.pub)
 #   │       └── additional.students/
 #   │           └── r42.CODENAME-SCENARIO-student-key_bob_{1..N} (+.pub)
-#   ├── passwords.env         ← passphrases and passwords (plaintext reference)
-#   └── summary.txt           ← full recap: paths, passwords, config locations
+#   └── summary.txt           ← workspace orientation : paths + SSH hosts
+#                                (secrets moved to the ansible vault ; see
+#                                 `range42-context show-vault` on the deployer-cli)
 #
 # Variables consumed:
 #   - INFRASTRUCTURE_CODENAME       (required)
@@ -37,6 +38,8 @@
 - import_tasks: ./01_generate_passwords.yml
 - import_tasks: ./02_generate_ssh_keys.yml
 - import_tasks: ./03_generate_student_extra_keys.yml
-- import_tasks: ./04_write_passwords_env.yml
+# COMMENT BLOCK BEFORE CHORE-DELETE :
+# passwords.env generation disabled - secrets now live in the ansible vault.
+# - import_tasks: ./04_write_passwords_env.yml
 - import_tasks: ./05_export_pubkeys_as_facts.yml
 - import_tasks: ./06_write_summary.yml

--- a/roles/credentials.generate/templates/passwords.env.j2
+++ b/roles/credentials.generate/templates/passwords.env.j2
@@ -1,3 +1,9 @@
+{# COMMENT BLOCK BEFORE CHORE-DELETE :
+   passwords.env generation removed - all secrets now live in the ansible vault.
+   View with `range42-context show-vault` (deployer-cli) or `ansible-vault view`.
+   Template body kept commented for short-term rollback ; delete entirely in
+   a follow-up chore.
+
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 #
 # AUTO-GENERATED - DO NOT COMMIT :)
@@ -19,3 +25,4 @@
     ADMIN_VM_CI_PASSWORD={{ generated_admin_password }}
     TRAINEE_VM_CI_PASSWORD={{ generated_trainee_password }}
     WAZUH_ADMIN_PASSWORD={{ generated_wazuh_password }}
+#}

--- a/roles/credentials.generate/templates/summary.txt.j2
+++ b/roles/credentials.generate/templates/summary.txt.j2
@@ -42,19 +42,25 @@
  2 - SSH KEY PASSPHRASES
 ==============================================================================
 
-    px root    : {{ generated_px_root_passphrase }}
-    px jump    : {{ generated_px_jump_passphrase }}
-    alice      : {{ generated_deployer_passphrase }}
-    bob        : {{ generated_student_passphrase }}
+  Moved to the ansible vault. View with :
+    `range42-context show-vault`  (on the deployer-cli)
+    OR `ansible-vault view {{ vault_output_dir | default(credentials_output_dir ~ "/secrets") }}/default_vault.yml --vault-password-file ...`
+
+    px root    : <moved to vault — field ssh_passphrase_px_root>
+    px jump    : <moved to vault — field ssh_passphrase_px_jump>
+    alice      : <moved to vault — field ssh_passphrase_deployer_admin>
+    bob        : <moved to vault — field ssh_passphrase_student_user>
 
 
 ==============================================================================
  3 - VM USER PASSWORDS
 ==============================================================================
 
-    alice (admin)   : {{ generated_admin_password }}
-    bob (student)   : {{ generated_trainee_password }}
-    wazuh (admin)   : {{ generated_wazuh_password }}
+  Moved to the ansible vault. View with `range42-context show-vault`.
+
+    alice (admin)   : <moved to vault — field default_admin_vm_ci_password>
+    bob (student)   : <moved to vault — field default_trainee_vm_ci_password>
+    wazuh (admin)   : <moved to vault — field infrastructure_wazuh_admin_password>
 
 
 ==============================================================================

--- a/roles/credentials.vault/templates/default_vault.yml.j2
+++ b/roles/credentials.vault/templates/default_vault.yml.j2
@@ -32,19 +32,29 @@ proxmox_default_network_card_interface: "{{ infrastructure_proxmox_default_netwo
 
 
 ###############################################################################
-# 2 - SSH KEY PATHS
+# 2 - SSH KEY PATHS (paths on the host that rendered this vault - the laptop)
 ###############################################################################
 
+ssh_key_px_root: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root"
+ssh_key_px_jump: "{{ credentials_output_dir }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.jump_user"
 ssh_key_deployer_admin: "{{ credentials_output_dir }}/ssh_keys/backend_keys/r42.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-deployer-key_alice"
 ssh_key_student_user: "{{ credentials_output_dir }}/ssh_keys/student_keys/r42.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-student-key_bob"
+{% for i in range(1, (student_additional_keys_count | default(0) | int) + 1) %}
+ssh_key_student_user_extra_{{ i }}: "{{ credentials_output_dir }}/ssh_keys/student_keys/additional.students/r42.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-student-key_bob_{{ i }}"
+{% endfor %}
 
 
 ###############################################################################
 # 3 - SSH PUBLIC KEY CONTENT
 ###############################################################################
 
+ssh_key_px_root_pub_key: "{{ generated_px_root_pubkey | default('') }}"
+ssh_key_px_jump_pub_key: "{{ generated_px_jump_pubkey | default('') }}"
 ssh_key_deployer_admin_pub_key: "{{ generated_admin_ssh_pubkey }}"
 ssh_key_student_user_pub_key: "{{ generated_trainee_ssh_pubkey }}"
+{% for i in range(1, (student_additional_keys_count | default(0) | int) + 1) %}
+ssh_key_student_user_extra_{{ i }}_pub_key: "{{ (generated_student_extra_pubkeys | default([]))[i-1] | default('') }}"
+{% endfor %}
 
 
 ###############################################################################
@@ -71,3 +81,14 @@ deployer_cli_user_ssh_known_hosts: "/home/{{ DEPLOYER_CLI_USER }}/.ssh/known_hos
 infrastructure_tailscale_authkey: "{{ infrastructure_tailscale_authkey }}"
 infrastructure_tailscale_apikey: "{{ infrastructure_tailscale_apikey }}"
 infrastructure_wazuh_admin_password: "{{ generated_wazuh_password }}"
+
+
+###############################################################################
+# 6 - SSH KEY PASSPHRASES (auto-unlock by range42-context use via SSH_ASKPASS)
+###############################################################################
+
+ssh_passphrase_px_root:                "{{ generated_px_root_passphrase | default('') }}"
+ssh_passphrase_px_jump:                "{{ generated_px_jump_passphrase | default('') }}"
+ssh_passphrase_deployer_admin:         "{{ generated_deployer_passphrase | default('') }}"
+ssh_passphrase_student_user:           "{{ generated_student_passphrase | default('') }}"
+ssh_passphrase_student_user_extra_all: "{{ generated_student_extra_passphrase | default('') }}"

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -499,10 +499,10 @@ _r42_use() {
 }
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
-# range42-context inventory — show ansible inventory tree
+# range42-context show-inventory — show ansible inventory tree
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
-_r42_inventory() {
+_r42_show_inventory() {
 
     local inventory_dir="${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:-}"
 
@@ -644,31 +644,86 @@ _r42_status() {
 }
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
-# range42-context passwords — show generated credentials
+# COMMENT BLOCK BEFORE CHORE-DELETE :
+# `range42-context passwords` removed - replaced by `show-vault` (secrets via
+# ansible-vault view) + `show-config` (non-secret orientation via summary.txt).
+# Function body kept commented for short-term rollback ; delete entirely in a
+# follow-up chore.
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
-_r42_passwords() {
-    local config_dir="${RANGE42_ACTIVE_CONFIG_DIR:-}"
+# _r42_passwords() {
+#     local config_dir="${RANGE42_ACTIVE_CONFIG_DIR:-}"
+#
+#     if [[ -z "$config_dir" ]]; then
+#         _r42_print_fail "no active workspace"
+#         return 1
+#     fi
+#
+#     # try summary.txt first, then passwords.env
+#     local summary="$config_dir/summary.txt"
+#     local passwords="$config_dir/passwords.env"
+#
+#     if [[ -f "$summary" ]]; then
+#         _r42_print_section "credentials summary"
+#         cat "$summary"
+#     elif [[ -f "$passwords" ]]; then
+#         _r42_print_section "passwords"
+#         cat "$passwords"
+#     else
+#         _r42_print_fail "no summary.txt or passwords.env found in $config_dir"
+#         _r42_print_warning "credentials may not have been generated yet"
+#     fi
+# }
 
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+# range42-context show-vault — show ansible vault contents (decrypted on the fly)
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+
+_r42_show_vault() {
+    local config_dir="${RANGE42_ACTIVE_CONFIG_DIR:-}"
     if [[ -z "$config_dir" ]]; then
         _r42_print_fail "no active workspace"
+        _r42_print_warning "run: range42-context use <codename> <scenario>"
         return 1
     fi
 
-    # try summary.txt first, then passwords.env
-    local summary="$config_dir/summary.txt"
-    local passwords="$config_dir/passwords.env"
+    local vault_file="${config_dir%/}/secrets/default_vault.yml"
+    local vault_pass_file="${RANGE42_VAULT_PASSWORD_FILE:-${config_dir%/}/secrets/vault_pass.txt}"
 
-    if [[ -f "$summary" ]]; then
-        _r42_print_section "credentials summary"
-        cat "$summary"
-    elif [[ -f "$passwords" ]]; then
-        _r42_print_section "passwords"
-        cat "$passwords"
-    else
-        _r42_print_fail "no summary.txt or passwords.env found in $config_dir"
-        _r42_print_warning "credentials may not have been generated yet"
+    if [[ ! -f "$vault_file" ]]; then
+        _r42_print_fail "vault file not found: $vault_file"
+        return 1
     fi
+    if [[ ! -f "$vault_pass_file" ]]; then
+        _r42_print_fail "vault password file not found: $vault_pass_file"
+        return 1
+    fi
+
+    _r42_print_section "ansible vault (credentials + SSH passphrases) — ${RANGE42_ACTIVE_WORKSPACE:-unknown}"
+    ansible-vault view "$vault_file" --vault-password-file "$vault_pass_file"
+}
+
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+# range42-context show-config — show workspace orientation (paths + SSH hosts)
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+
+_r42_show_config() {
+    local config_dir="${RANGE42_ACTIVE_CONFIG_DIR:-}"
+    if [[ -z "$config_dir" ]]; then
+        _r42_print_fail "no active workspace"
+        _r42_print_warning "run: range42-context use <codename> <scenario>"
+        return 1
+    fi
+
+    local summary="${config_dir%/}/summary.txt"
+    if [[ ! -f "$summary" ]]; then
+        _r42_print_fail "summary.txt not found in $config_dir"
+        _r42_print_warning "workspace may not have been fully deployed yet"
+        return 1
+    fi
+
+    _r42_print_section "workspace config summary — ${RANGE42_ACTIVE_WORKSPACE:-unknown}"
+    cat "$summary"
 }
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
@@ -1805,8 +1860,9 @@ _r42_help() {
     printf "    ${N}revert${R} <name>                  ${D}revert all scenario VMs to a snapshot${R}\n"
     echo ""
     printf "  ${C}info${R}\n"
-    printf "    ${N}inventory${R}                      ${D}show ansible inventory tree${R}\n"
-    printf "    ${N}passwords${R}                      ${D}show generated credentials${R}\n"
+    printf "    ${N}show-vault${R}                     ${D}show ansible vault contents (decrypted on the fly)${R}\n"
+    printf "    ${N}show-config${R}                    ${D}show workspace orientation (paths + SSH hosts)${R}\n"
+    printf "    ${N}show-inventory${R}                 ${D}show ansible inventory tree${R}\n"
     printf "    ${N}ssh${R} <pattern>                  ${D}quick ssh to a VM by name${R}\n"
     printf "    ${N}debug${R}                          ${D}toggle verbose output (show/hide skipped tasks)${R}\n"
     printf "    ${N}help${R}                           ${D}show this help${R}\n"
@@ -1848,8 +1904,9 @@ range42-context() {
         snapshot-list)      _r42_snapshot_list ;;
         revert)             _r42_revert "$@" ;;
         ssh-reload)     _r42_ssh_reload ;;
-        inventory|inv)  _r42_inventory ;;
-        passwords|pw)   _r42_passwords ;;
+        show-vault)     _r42_show_vault ;;
+        show-config)    _r42_show_config ;;
+        show-inventory) _r42_show_inventory ;;
         ssh)            _r42_ssh "$@" ;;
         cd)             _r42_cd "$@" ;;
         debug)          _r42_debug ;;

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -224,6 +224,59 @@ _r42_flush_known_hosts() {
 }
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+# helpers for vault-backed SSH key auto-unlock (used by _r42_ssh_reload)
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+
+# _r42_yaml_get — extract a top-level scalar field from YAML on stdin via yq.
+# Returns empty string if the field is absent or null.
+# usage : echo "$yaml" | _r42_yaml_get <field_name>
+_r42_yaml_get() {
+    local field="$1"
+    yq -r ".${field} // \"\""
+}
+
+# _r42_passphrase_field_for_key — map an SSH key file path to the YAML field
+# name in the vault that holds its passphrase. Echoes the field name on match,
+# empty otherwise.
+# usage : _r42_passphrase_field_for_key <key_file_path>
+_r42_passphrase_field_for_key() {
+    local keyfile="$1"
+    case "$keyfile" in
+        *ssh_cli.root)       echo "ssh_passphrase_px_root" ;;
+        *ssh_cli.jump_user)  echo "ssh_passphrase_px_jump" ;;
+        *deployer-key_alice) echo "ssh_passphrase_deployer_admin" ;;
+        *student-key_bob_*)  echo "ssh_passphrase_student_user_extra_all" ;;
+        *student-key_bob)    echo "ssh_passphrase_student_user" ;;
+        *)                   echo "" ;;
+    esac
+}
+
+# _r42_ssh_add_with_passphrase — non-interactive ssh-add via SSH_ASKPASS.
+# Creates a one-shot askpass tempfile script that prints $SSH_ASKPASS_PASSWORD,
+# invokes ssh-add with SSH_ASKPASS_REQUIRE=force and stdin from /dev/null so
+# ssh-add cannot fall back to /dev/tty, then cleans up the tempfile.
+# Returns ssh-add's exit code (0 on success, non-zero on bad passphrase / etc).
+# usage : _r42_ssh_add_with_passphrase <key_file_path> <passphrase>
+_r42_ssh_add_with_passphrase() {
+    local keyfile="$1"
+    local passphrase="$2"
+    local askpass_script rc
+
+    askpass_script=$(mktemp -t r42-askpass-XXXXXX.sh) || return 1
+    chmod 700 "$askpass_script"
+    printf '#!/bin/sh\nprintf "%%s" "$SSH_ASKPASS_PASSWORD"\n' > "$askpass_script"
+
+    SSH_ASKPASS="$askpass_script" \
+    SSH_ASKPASS_PASSWORD="$passphrase" \
+    SSH_ASKPASS_REQUIRE=force \
+        ssh-add "$keyfile" </dev/null >/dev/null 2>&1
+    rc=$?
+
+    rm -f "$askpass_script"
+    return $rc
+}
+
+#### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 # range42-context ssh-reload — reload SSH keys for active workspace (T45)
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
@@ -248,9 +301,25 @@ _r42_ssh_reload() {
         return 1
     }
 
+    # decrypt the vault once for passphrase lookup. On any failure (missing
+    # vault_pass.txt, missing vault file, decrypt error), $vault_content stays
+    # empty and the per-key loop falls back to interactive ssh-add. No abort.
+    local vault_file vault_pass_file vault_content=""
+    vault_file="${RANGE42_CONFIG__ROOT_DIR%/}/secrets/default_vault.yml"
+    vault_pass_file="${RANGE42_VAULT_PASSWORD_FILE:-}"
+
+    if [[ -n "$vault_pass_file" && -f "$vault_pass_file" && -f "$vault_file" ]]; then
+        vault_content=$(ansible-vault view "$vault_file" \
+            --vault-password-file "$vault_pass_file" 2>/dev/null) \
+            || vault_content=""
+    fi
+
+    if [[ -z "$vault_content" && "$verbose" == "-v" ]]; then
+        _r42_print_warning "vault not readable - ssh-add will prompt interactively for passphrase-protected keys"
+    fi
+
     # parse active ssh config for IdentityFile entries
     # FIX P4: trim leading whitespace from IdentityFile paths
-    local key_count=0
     grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" |
         grep 'config_range42' |
         grep -v '^#' |
@@ -263,8 +332,28 @@ _r42_ssh_reload() {
                     if [[ "$verbose" == "-v" ]]; then
                         _r42_print_warning "loading: $identity_file"
                     fi
-                    ssh-add "$identity_file" </dev/tty 2>/dev/null
-                    key_count=$((key_count + 1))
+
+                    # try passphrase lookup from vault first
+                    local field="" passphrase=""
+                    if [[ -n "$vault_content" ]]; then
+                        field=$(_r42_passphrase_field_for_key "$identity_file")
+                        if [[ -n "$field" ]]; then
+                            passphrase=$(echo "$vault_content" | _r42_yaml_get "$field")
+                        fi
+                    fi
+
+                    if [[ -n "$passphrase" ]]; then
+                        # non-interactive via SSH_ASKPASS ; fall back to /dev/tty
+                        # if the vault passphrase does not match the key (desync).
+                        if ! _r42_ssh_add_with_passphrase "$identity_file" "$passphrase"; then
+                            ssh-add "$identity_file" </dev/tty 2>/dev/null
+                        fi
+                    else
+                        # vault unreadable, field absent, or empty passphrase :
+                        # plain ssh-add. Loads unprotected keys silently, prompts
+                        # for protected ones via /dev/tty (legacy behavior).
+                        ssh-add "$identity_file" </dev/tty 2>/dev/null
+                    fi
                 done
         done
 

--- a/roles/proxmox.init/tasks/00_load_root_ssh_key.yml
+++ b/roles/proxmox.init/tasks/00_load_root_ssh_key.yml
@@ -6,6 +6,20 @@
 #
 # ssh-agent is guaranteed to be running by playbook 02 pre_tasks
 #
+# When the root SSH key is generated with a passphrase (default since the
+# wizard uses context_ssh_keys_use_passphrase=YES), ssh-add cannot prompt
+# interactively from ansible (no tty). We feed the passphrase via the
+# SSH_ASKPASS pattern : a tempfile script that echoes $SSH_ASKPASS_PASSWORD,
+# pointed to by SSH_ASKPASS env, with SSH_ASKPASS_REQUIRE=force to make
+# ssh-add use the askpass even when DISPLAY is unset. The passphrase comes
+# from the generated_px_root_passphrase fact set by credentials.generate
+# in playbook 01 (host facts persist across import_playbook within the
+# same ansible-playbook invocation).
+#
+# When the key has no passphrase (legacy mode), the passphrase fact is empty
+# string and ssh-add does not need to invoke askpass at all - the env vars
+# are set but unused.
+#
 # source: proxmox_load_root_ssh_key() lines 757-775
 
 - name: PROXMOX INIT - CLEAR ALL KEYS FROM AGENT (AVOID TOO MANY AUTH FAILURES)
@@ -13,7 +27,39 @@
   changed_when: true
   failed_when: false
 
+- name: PROXMOX INIT - CREATE SSH_ASKPASS HELPER TEMPFILE
+  ansible.builtin.copy:
+    content: |
+      #!/bin/sh
+      printf "%s" "$SSH_ASKPASS_PASSWORD"
+    dest: "/tmp/r42-askpass-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.sh"
+    mode: '0700'
+
 - name: PROXMOX INIT - LOAD PROXMOX ROOT SSH KEY INTO AGENT
   ansible.builtin.command: ssh-add "{{ proxmox_root_ssh_key_path }}"
-  register: ssh_add_result
-  changed_when: "'Identity added' in ssh_add_result.stdout"
+  environment:
+    SSH_ASKPASS: "/tmp/r42-askpass-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.sh"
+    SSH_ASKPASS_PASSWORD: "{{ generated_px_root_passphrase | default('') }}"
+    SSH_ASKPASS_REQUIRE: force
+  register: ssh_add_root_result
+  changed_when: "'Identity added' in ssh_add_root_result.stdout"
+  no_log: true
+
+# Also load the jump SSH key into the agent so subsequent tasks in proxmox.jump-user
+# (e.g., the BatchMode `ssh -i jump_key jump_user@px true` verify step) can use it
+# without prompting. The jump key is encrypted with generated_px_jump_passphrase
+# (same fact propagation as root passphrase).
+- name: PROXMOX INIT - LOAD PROXMOX JUMP SSH KEY INTO AGENT
+  ansible.builtin.command: ssh-add "{{ proxmox_jump_ssh_key_path }}"
+  environment:
+    SSH_ASKPASS: "/tmp/r42-askpass-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.sh"
+    SSH_ASKPASS_PASSWORD: "{{ generated_px_jump_passphrase | default('') }}"
+    SSH_ASKPASS_REQUIRE: force
+  register: ssh_add_jump_result
+  changed_when: "'Identity added' in ssh_add_jump_result.stdout"
+  no_log: true
+
+- name: PROXMOX INIT - CLEANUP SSH_ASKPASS HELPER TEMPFILE
+  ansible.builtin.file:
+    path: "/tmp/r42-askpass-{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}.sh"
+    state: absent

--- a/roles/workspace.credentials/tasks/04_deploy_workspace_summary.yml
+++ b/roles/workspace.credentials/tasks/04_deploy_workspace_summary.yml
@@ -1,0 +1,17 @@
+---
+# workspace credentials - deploy summary.txt to the deployer-cli workspace
+#
+# summary.txt is generated locally by credentials.generate/06_write_summary.yml
+# and contains the non-secret workspace orientation (paths + SSH hosts).
+# It is consumed by `range42-context show-config` on the deployer-cli.
+#
+# Secrets (SSH passphrases + VM passwords) are no longer in summary.txt -
+# they live in the ansible vault (see `range42-context show-vault`).
+
+- name: WORKSPACE CREDENTIALS - DEPLOY SUMMARY.TXT TO DEPLOYER-CLI
+  ansible.builtin.copy:
+    src: "{{ INFRASTRUCTURE__AUTO_GENERATED__CONFIG_DIR_LOCAL }}/summary.txt"
+    dest: "{{ DEPLOYER_CLI__DST_CONFIG_DIR }}/summary.txt"
+    owner: "{{ DEPLOYER_CLI_USER }}"
+    group: "{{ DEPLOYER_CLI_USER }}"
+    mode: "0600"

--- a/roles/workspace.credentials/tasks/main.yml
+++ b/roles/workspace.credentials/tasks/main.yml
@@ -32,3 +32,4 @@
 - import_tasks: ./01_deploy_ssh_keys.yml
 - import_tasks: ./02_deploy_secrets.yml
 - import_tasks: ./03_deploy_sourced_env.yml
+- import_tasks: ./04_deploy_workspace_summary.yml

--- a/wizard/preflight.py
+++ b/wizard/preflight.py
@@ -33,12 +33,31 @@ COLLECTIONS = [
     "community.general",
 ]
 
+# Python modules required by Ansible modules invoked from playbook 01.
+# community.crypto.openssh_keypair needs bcrypt to create passphrase-protected
+# ed25519 keys (the cryptography library uses bcrypt for the AES key derivation
+# when encrypting the private key file). Without bcrypt installed, the wizard
+# fails at the GENERATE PROXMOX ROOT SSH KEY task with :
+#     cryptography.exceptions.UnsupportedAlgorithm: Need bcrypt module
+PYTHON_DEPS = [
+    {"label": "python3-bcrypt", "module": "bcrypt", "fix": "sudo apt install python3-bcrypt", "required": True, "manual": False},
+]
+
 
 # ── detection functions ──────────────────────────────────────────────────────
 
 def check_command(cmd):
     """Check if a command is available in PATH."""
     return shutil.which(cmd) is not None
+
+
+def check_python_module(name):
+    """Check if a Python module is importable from the current python3."""
+    r = subprocess.run(
+        ["python3", "-c", f"import {name}"],
+        capture_output=True,
+    )
+    return r.returncode == 0
 
 
 def get_version(cmd):
@@ -133,6 +152,29 @@ def run_all_checks(example_dir):
             "detail": detail,
             "required": check["required"],
             "apt_fix": check["fix"] if not ok and not check.get("manual") and (check.get("fix") or "").startswith("sudo apt") else None,
+        })
+
+    # python module checks (e.g., bcrypt for openssh_keypair with passphrase)
+    for dep in PYTHON_DEPS:
+        ok = check_python_module(dep["module"])
+
+        if ok:
+            badge = "PASS"
+            detail = ""
+        elif dep["required"]:
+            badge = "FAIL"
+            detail = f"  {dep['fix']}  [Install & retry]"
+            fail = True
+        else:
+            badge = "WARN"
+            detail = f"  {dep['fix']}  [Install & retry]"
+
+        results.append({
+            "badge": badge,
+            "label": dep["label"],
+            "detail": detail,
+            "required": dep["required"],
+            "apt_fix": dep["fix"] if not ok and (dep.get("fix") or "").startswith("sudo apt") else None,
         })
 
     # collection checks


### PR DESCRIPTION
## Summary
## Summary 

- Auto-unlock SSH keys from the ansible vault when activating a workspace (removes the manual `ssh-add` + passphrase prompt loop). Wizard default flips to `passphrase=YES`. Per-codename, per-scenario passphrases stored in the vault.
- New `range42-context` info commands : `show-vault` (decrypted credentials + SSH passphrases view), `show-config` (workspace orientation), `show-inventory` (rename of the old `inventory` / `inv`). Soft-removes the obsolete `passwords` subcommand (the vault is now the source of truth).
- Wizard fix : `--catalog-try` mode no longer loses the `catalog_try` scenario when overwriting an existing codename that had a previous scenario deployed.

## Commits

- `7a37cac` feat(range42-context): SSH key auto-unlock from vault on workspace use (#191)
- `e5bd0dc` fix(credentials.generate): regenerate openssh_keypair with full_idempotence to handle workspace overwrite (#191)
- `492c56e` fix: complete SSH key auto-unlock flow on workspace overwrite (bcrypt preflight + SSH_ASKPASS for proxmox keys + regenerate=always) (#191)
- `682ef2d` feat(range42-context): show-vault + show-config + show-inventory commands (#192)
- `fa38c5a` fix(range42-init): preserve --catalog-try scenario through prefill() on workspace overwrite (#193)

Closes #191, #192, #193.

## Test plan

- [ ] Fresh wizard run on a clean codename : SSH keys generated with passphrases, vault populated, `range42-context use <codename> <scenario>` unlocks all keys without prompting.
- [ ] Wizard re-run (overwrite) on an existing codename : `regenerate=always` rotates keys, vault stays in sync, no `bcrypt module` failure (preflight catches missing python3-bcrypt and offers Install button).
- [ ] `proxmox.init` runs end-to-end against a Proxmox host with passphrase-protected root + jump keys, no interactive prompt (SSH_ASKPASS pattern).
- [ ] `range42-context show-vault` displays the full decrypted vault (credentials + SSH passphrases).
- [ ] `range42-context show-config` displays the workspace summary (paths + SSH hosts, with vault-pointer notes in sections 2 + 3 where the SSH passphrases / VM passwords used to live inline).
- [ ] `range42-context show-inventory` displays the Ansible inventory.
- [ ] `range42-context passwords` and `range42-context inventory` return `unknown command` (removed / renamed).
- [ ] `./range42-init.py --catalog-try docker/_ctf/hello` against an existing codename with a prior scenario shows `range42-context use <codename> catalog_try` in the post-deploy banner (regression test for the prefill() override fix).

