### PR TITLE
fix(range42-context): vault passphrase invisible in ssh-reload while loop

### DIFF
--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -318,44 +318,44 @@ _r42_ssh_reload() {
         _r42_print_warning "vault not readable - ssh-add will prompt interactively for passphrase-protected keys"
     fi
 
-    # parse active ssh config for IdentityFile entries
-    # FIX P4: trim leading whitespace from IdentityFile paths
-    grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" |
-        grep 'config_range42' |
-        grep -v '^#' |
-        sed 's/^Include //' |
-        while read -r config_file; do
-            grep 'IdentityFile ' "$config_file" 2>/dev/null |
-                sed 's/^[[:space:]]*IdentityFile[[:space:]]*//' |
-                sort -u |
-                while read -r identity_file; do
-                    if [[ "$verbose" == "-v" ]]; then
-                        _r42_print_warning "loading: $identity_file"
-                    fi
+    # parse active ssh config for IdentityFile entries.
+    # Process substitution (<(...)) keeps the while loops in the current shell
+    # so vault_content (set above) is visible — pipelines fork subshells in
+    # interactive ZSH (job control enabled) and would lose the variable.
+    while IFS= read -r config_file; do
+        while IFS= read -r identity_file; do
+            if [[ "$verbose" == "-v" ]]; then
+                _r42_print_warning "loading: $identity_file"
+            fi
 
-                    # try passphrase lookup from vault first
-                    local field="" passphrase=""
-                    if [[ -n "$vault_content" ]]; then
-                        field=$(_r42_passphrase_field_for_key "$identity_file")
-                        if [[ -n "$field" ]]; then
-                            passphrase=$(echo "$vault_content" | _r42_yaml_get "$field")
-                        fi
-                    fi
+            # try passphrase lookup from vault first
+            local field="" passphrase=""
+            if [[ -n "$vault_content" ]]; then
+                field=$(_r42_passphrase_field_for_key "$identity_file")
+                if [[ -n "$field" ]]; then
+                    passphrase=$(echo "$vault_content" | _r42_yaml_get "$field")
+                fi
+            fi
 
-                    if [[ -n "$passphrase" ]]; then
-                        # non-interactive via SSH_ASKPASS ; fall back to /dev/tty
-                        # if the vault passphrase does not match the key (desync).
-                        if ! _r42_ssh_add_with_passphrase "$identity_file" "$passphrase"; then
-                            ssh-add "$identity_file" </dev/tty 2>/dev/null
-                        fi
-                    else
-                        # vault unreadable, field absent, or empty passphrase :
-                        # plain ssh-add. Loads unprotected keys silently, prompts
-                        # for protected ones via /dev/tty (legacy behavior).
-                        ssh-add "$identity_file" </dev/tty 2>/dev/null
-                    fi
-                done
-        done
+            if [[ -n "$passphrase" ]]; then
+                # non-interactive via SSH_ASKPASS ; fall back to /dev/tty
+                # if the vault passphrase does not match the key (desync).
+                if ! _r42_ssh_add_with_passphrase "$identity_file" "$passphrase"; then
+                    ssh-add "$identity_file" </dev/tty 2>/dev/null
+                fi
+            else
+                # vault unreadable, field absent, or empty passphrase :
+                # plain ssh-add. Loads unprotected keys silently, prompts
+                # for protected ones via /dev/tty (legacy behavior).
+                ssh-add "$identity_file" </dev/tty 2>/dev/null
+            fi
+        done < <(grep 'IdentityFile ' "$config_file" 2>/dev/null \
+                     | sed 's/^[[:space:]]*IdentityFile[[:space:]]*//' \
+                     | sort -u)
+    done < <(grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" \
+                 | grep 'config_range42' \
+                 | grep -v '^#' \
+                 | sed 's/^Include //')
 
     local loaded
     loaded=$(ssh-add -l 2>/dev/null | wc -l)


### PR DESCRIPTION
Closes #200

## Problem

In an interactive ZSH shell (job control enabled), each stage of a `|` pipeline runs in a subshell. `vault_content` is set before the pipeline but **never visible** inside `while read` loops — the passphrase is always empty so `ssh-add` falls back to the `/dev/tty` interactive prompt, defeating the vault-based auto-unlock introduced in #195.

## Fix

Replace both nested `| while read` constructs with **process substitution** (`< <(...)`):

```bash
# Before — subshell loses vault_content
grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" | ... | while read -r config_file; do
    grep 'IdentityFile ' ... | while read -r identity_file; do

# After — current shell sees vault_content
while IFS= read -r config_file; do
    while IFS= read -r identity_file; do
        ...
    done < <(grep 'IdentityFile ' "$config_file" | sort -u)
done < <(grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" | ...)
```

## Files changed

- `roles/deployer.bootstrap/files/range42-context.sh` — `_r42_reload_ssh_agent` function

## Test plan

- [ ] `range42-context ssh-reload` auto-loads passphrase-protected keys without prompting for input
- [ ] Re-running `ssh-reload` is idempotent (agent already has keys → no-op)
- [ ] Unprotected keys still load silently