### PR TITLE
feat(range42-context): delete-everything — R42-FORWARD teardown + non-fatal empty VM list

### DIFF
--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1146,34 +1146,18 @@ _r42_delete_everything() {
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
-    # flush R42-FORWARD iptables chain if any scenario had network isolation
-    local first_teardown=""
-    for m in "${manifests[@]}"; do
-        local scn_dir="${m%/manifest/scenario_vms.json}"
-        local teardown_yml="${scn_dir}/05_network_isolation/teardown.yml"
-        if [[ -f "$teardown_yml" ]]; then
-            first_teardown="$teardown_yml"
-            break
-        fi
-    done
-
-    if [[ -n "$first_teardown" ]]; then
-        local inv_dir="${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:-}"
-        local vault_pass="${RANGE42_VAULT_PASSWORD_FILE:-}"
-        if [[ -z "$inv_dir" || -z "$vault_pass" ]]; then
-            _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_ANSIBLE_ROLES__INVENTORY_DIR or RANGE42_VAULT_PASSWORD_FILE not set (run: range42-context use <codename> <scenario>)"
-        else
-            echo ""
-            _r42_print_step "flushing R42-FORWARD iptables chain (network isolation teardown) ..."
-            (
-                cd "$(dirname "$first_teardown")" && \
-                ansible-playbook \
-                    -i "${inv_dir}/inventory_default.yml" \
-                    -l "all" \
-                    "./teardown.yml" \
-                    --vault-password-file "${vault_pass}"
-            ) || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
-        fi
+    # flush R42-FORWARD iptables chain via direct SSH to proxmox-cli
+    local codename="${RANGE42_INFRASTRUCTURE_CODENAME:-}"
+    if [[ -z "$codename" ]]; then
+        _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_INFRASTRUCTURE_CODENAME not set (run: range42-context use <codename> <scenario>)"
+    else
+        local px_cli="${codename}-cli"
+        echo ""
+        _r42_print_step "flushing R42-FORWARD iptables chain on $px_cli ..."
+        ssh "$px_cli" \
+            'iptables -D FORWARD -j R42-FORWARD 2>/dev/null; iptables -F R42-FORWARD 2>/dev/null; iptables -X R42-FORWARD 2>/dev/null; true' \
+            && _r42_print_check "R42-FORWARD chain removed" \
+            || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
     fi
 
     echo ""

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1146,6 +1146,36 @@ _r42_delete_everything() {
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
+    # flush R42-FORWARD iptables chain if any scenario had network isolation
+    local first_teardown=""
+    for m in "${manifests[@]}"; do
+        local scn_dir="${m%/manifest/scenario_vms.json}"
+        local teardown_yml="${scn_dir}/05_network_isolation/teardown.yml"
+        if [[ -f "$teardown_yml" ]]; then
+            first_teardown="$teardown_yml"
+            break
+        fi
+    done
+
+    if [[ -n "$first_teardown" ]]; then
+        local inv_dir="${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:-}"
+        local vault_pass="${RANGE42_VAULT_PASSWORD_FILE:-}"
+        if [[ -z "$inv_dir" || -z "$vault_pass" ]]; then
+            _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_ANSIBLE_ROLES__INVENTORY_DIR or RANGE42_VAULT_PASSWORD_FILE not set (run: range42-context use <codename> <scenario>)"
+        else
+            echo ""
+            _r42_print_step "flushing R42-FORWARD iptables chain (network isolation teardown) ..."
+            (
+                cd "$(dirname "$first_teardown")" && \
+                ansible-playbook \
+                    -i "${inv_dir}/inventory_default.yml" \
+                    -l "all" \
+                    "./teardown.yml" \
+                    --vault-password-file "${vault_pass}"
+            ) || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
+        fi
+    fi
+
     echo ""
     _r42_print_step "cleaning ${#all_ips[@]} known_hosts entries ..."
     for ip in "${all_ips[@]}"; do

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1089,7 +1089,7 @@ _r42_delete_everything() {
     fi
 
     _r42_print_section "DELETE EVERYTHING — cross-scenario nuke"
-    _r42_print_warning "this will destroy ALL VMs + templates referenced by EVERY scenario manifest on this Proxmox"
+    _r42_print_warning "this will destroy ALL VMs + templates referenced by EVERY scenario manifest on this Proxmox, and flush ALL R42-FORWARD firewall rules"
     echo ""
     echo "  scenarios with a manifest:"
     for m in "${manifests[@]}"; do


### PR DESCRIPTION
Closes #205

## Context

The `range42-catalog` repo (`feat/topology-layer-templates` branch) introduces a **topology layer** with reusable network policies. When a scenario is deployed with a network policy, Ansible sets up an `R42-FORWARD` iptables chain on the Proxmox node to enforce inter-subnet isolation. Before this work, `delete-everything` left that chain behind on every teardown — requiring a manual `iptables -X R42-FORWARD` on the hypervisor.

This PR makes `delete-everything` topology-aware: it tears the chain down as part of the nuke sequence, so the Proxmox node is left in a clean state regardless of which network policy was applied.

## Summary

- **R42-FORWARD firewall teardown**: `delete-everything` now SSHes directly to `${RANGE42_INFRASTRUCTURE_CODENAME}-cli` after VM deletion and flushes/removes the R42-FORWARD iptables chain. Non-fatal — a warning is printed if the chain was never deployed or codename is unset.
- **Non-fatal empty VM list**: when `proxmox_vm.list.to.jsons.sh` returns no data, VM stop/delete is skipped with a warning rather than aborting the entire nuke. Firewall teardown and `known_hosts` cleanup always run.
- **Warning message** updated to mention R42-FORWARD flush.

> **Merge dependency**: this PR should be merged after #201 (revert direct-pushed commit) and #202 (ssh-reload fix) land in `dev`. The branch has been rebased to exclude the ssh-reload commit — it carries only the 4 delete-everything commits.

## Test plan

- [ ] `range42-context delete-everything` with VMs present — stops + deletes VMs, flushes R42-FORWARD, cleans known_hosts
- [ ] `range42-context delete-everything` with no VMs on Proxmox — prints warning, still flushes R42-FORWARD and cleans known_hosts
- [ ] `range42-context delete-everything` without `range42-context use` set — prints warning for R42-FORWARD teardown, continues
- [ ] R42-FORWARD chain not present on proxmox-cli — teardown returns non-zero but is treated as non-fatal