### PR TITLE
feat(range42-context): delete-everything — R42-FORWARD chain teardown

### DIFF
--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1146,34 +1146,18 @@ _r42_delete_everything() {
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
-    # flush R42-FORWARD iptables chain if any scenario had network isolation
-    local first_teardown=""
-    for m in "${manifests[@]}"; do
-        local scn_dir="${m%/manifest/scenario_vms.json}"
-        local teardown_yml="${scn_dir}/05_network_isolation/teardown.yml"
-        if [[ -f "$teardown_yml" ]]; then
-            first_teardown="$teardown_yml"
-            break
-        fi
-    done
-
-    if [[ -n "$first_teardown" ]]; then
-        local inv_dir="${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:-}"
-        local vault_pass="${RANGE42_VAULT_PASSWORD_FILE:-}"
-        if [[ -z "$inv_dir" || -z "$vault_pass" ]]; then
-            _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_ANSIBLE_ROLES__INVENTORY_DIR or RANGE42_VAULT_PASSWORD_FILE not set (run: range42-context use <codename> <scenario>)"
-        else
-            echo ""
-            _r42_print_step "flushing R42-FORWARD iptables chain (network isolation teardown) ..."
-            (
-                cd "$(dirname "$first_teardown")" && \
-                ansible-playbook \
-                    -i "${inv_dir}/inventory_default.yml" \
-                    -l "all" \
-                    "./teardown.yml" \
-                    --vault-password-file "${vault_pass}"
-            ) || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
-        fi
+    # flush R42-FORWARD iptables chain via direct SSH to proxmox-cli
+    local codename="${RANGE42_INFRASTRUCTURE_CODENAME:-}"
+    if [[ -z "$codename" ]]; then
+        _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_INFRASTRUCTURE_CODENAME not set (run: range42-context use <codename> <scenario>)"
+    else
+        local px_cli="${codename}-cli"
+        echo ""
+        _r42_print_step "flushing R42-FORWARD iptables chain on $px_cli ..."
+        ssh "$px_cli" \
+            'iptables -D FORWARD -j R42-FORWARD 2>/dev/null; iptables -F R42-FORWARD 2>/dev/null; iptables -X R42-FORWARD 2>/dev/null; true' \
+            && _r42_print_check "R42-FORWARD chain removed" \
+            || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
     fi
 
     echo ""

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1146,6 +1146,36 @@ _r42_delete_everything() {
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
     echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
+    # flush R42-FORWARD iptables chain if any scenario had network isolation
+    local first_teardown=""
+    for m in "${manifests[@]}"; do
+        local scn_dir="${m%/manifest/scenario_vms.json}"
+        local teardown_yml="${scn_dir}/05_network_isolation/teardown.yml"
+        if [[ -f "$teardown_yml" ]]; then
+            first_teardown="$teardown_yml"
+            break
+        fi
+    done
+
+    if [[ -n "$first_teardown" ]]; then
+        local inv_dir="${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:-}"
+        local vault_pass="${RANGE42_VAULT_PASSWORD_FILE:-}"
+        if [[ -z "$inv_dir" || -z "$vault_pass" ]]; then
+            _r42_print_warning "skipping R42-FORWARD teardown — RANGE42_ANSIBLE_ROLES__INVENTORY_DIR or RANGE42_VAULT_PASSWORD_FILE not set (run: range42-context use <codename> <scenario>)"
+        else
+            echo ""
+            _r42_print_step "flushing R42-FORWARD iptables chain (network isolation teardown) ..."
+            (
+                cd "$(dirname "$first_teardown")" && \
+                ansible-playbook \
+                    -i "${inv_dir}/inventory_default.yml" \
+                    -l "all" \
+                    "./teardown.yml" \
+                    --vault-password-file "${vault_pass}"
+            ) || _r42_print_warning "R42-FORWARD teardown returned non-zero (chain may not have been deployed — safe to ignore)"
+        fi
+    fi
+
     echo ""
     _r42_print_step "cleaning ${#all_ips[@]} known_hosts entries ..."
     for ip in "${all_ips[@]}"; do

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -318,44 +318,44 @@ _r42_ssh_reload() {
         _r42_print_warning "vault not readable - ssh-add will prompt interactively for passphrase-protected keys"
     fi
 
-    # parse active ssh config for IdentityFile entries
-    # FIX P4: trim leading whitespace from IdentityFile paths
-    grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" |
-        grep 'config_range42' |
-        grep -v '^#' |
-        sed 's/^Include //' |
-        while read -r config_file; do
-            grep 'IdentityFile ' "$config_file" 2>/dev/null |
-                sed 's/^[[:space:]]*IdentityFile[[:space:]]*//' |
-                sort -u |
-                while read -r identity_file; do
-                    if [[ "$verbose" == "-v" ]]; then
-                        _r42_print_warning "loading: $identity_file"
-                    fi
+    # parse active ssh config for IdentityFile entries.
+    # Process substitution (<(...)) keeps the while loops in the current shell
+    # so vault_content (set above) is visible — pipelines fork subshells in
+    # interactive ZSH (job control enabled) and would lose the variable.
+    while IFS= read -r config_file; do
+        while IFS= read -r identity_file; do
+            if [[ "$verbose" == "-v" ]]; then
+                _r42_print_warning "loading: $identity_file"
+            fi
 
-                    # try passphrase lookup from vault first
-                    local field="" passphrase=""
-                    if [[ -n "$vault_content" ]]; then
-                        field=$(_r42_passphrase_field_for_key "$identity_file")
-                        if [[ -n "$field" ]]; then
-                            passphrase=$(echo "$vault_content" | _r42_yaml_get "$field")
-                        fi
-                    fi
+            # try passphrase lookup from vault first
+            local field="" passphrase=""
+            if [[ -n "$vault_content" ]]; then
+                field=$(_r42_passphrase_field_for_key "$identity_file")
+                if [[ -n "$field" ]]; then
+                    passphrase=$(echo "$vault_content" | _r42_yaml_get "$field")
+                fi
+            fi
 
-                    if [[ -n "$passphrase" ]]; then
-                        # non-interactive via SSH_ASKPASS ; fall back to /dev/tty
-                        # if the vault passphrase does not match the key (desync).
-                        if ! _r42_ssh_add_with_passphrase "$identity_file" "$passphrase"; then
-                            ssh-add "$identity_file" </dev/tty 2>/dev/null
-                        fi
-                    else
-                        # vault unreadable, field absent, or empty passphrase :
-                        # plain ssh-add. Loads unprotected keys silently, prompts
-                        # for protected ones via /dev/tty (legacy behavior).
-                        ssh-add "$identity_file" </dev/tty 2>/dev/null
-                    fi
-                done
-        done
+            if [[ -n "$passphrase" ]]; then
+                # non-interactive via SSH_ASKPASS ; fall back to /dev/tty
+                # if the vault passphrase does not match the key (desync).
+                if ! _r42_ssh_add_with_passphrase "$identity_file" "$passphrase"; then
+                    ssh-add "$identity_file" </dev/tty 2>/dev/null
+                fi
+            else
+                # vault unreadable, field absent, or empty passphrase :
+                # plain ssh-add. Loads unprotected keys silently, prompts
+                # for protected ones via /dev/tty (legacy behavior).
+                ssh-add "$identity_file" </dev/tty 2>/dev/null
+            fi
+        done < <(grep 'IdentityFile ' "$config_file" 2>/dev/null \
+                     | sed 's/^[[:space:]]*IdentityFile[[:space:]]*//' \
+                     | sort -u)
+    done < <(grep '^Include ' "$RANGE42_SSH_CONFIG_FILE" \
+                 | grep 'config_range42' \
+                 | grep -v '^#' \
+                 | sed 's/^Include //')
 
     local loaded
     loaded=$(ssh-add -l 2>/dev/null | wc -l)

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1139,12 +1139,11 @@ _r42_delete_everything() {
     local _vm_list_json
     _vm_list_json=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
     if [ -z "$_vm_list_json" ]; then
-        _r42_print_fail "proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting nuke"
-        _r42_print_warning "output: ${_vm_list_json[1,200]}"
-        return 1
+        _r42_print_warning "proxmox_vm.list.to.jsons.sh returned no VM data — skipping VM deletion (continuing with firewall + known_hosts cleanup)"
+    else
+        echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+        echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
     fi
-    echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-    echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
     # flush R42-FORWARD iptables chain via direct SSH to proxmox-cli
     local codename="${RANGE42_INFRASTRUCTURE_CODENAME:-}"

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1089,7 +1089,7 @@ _r42_delete_everything() {
     fi
 
     _r42_print_section "DELETE EVERYTHING — cross-scenario nuke"
-    _r42_print_warning "this will destroy ALL VMs + templates referenced by EVERY scenario manifest on this Proxmox"
+    _r42_print_warning "this will destroy ALL VMs + templates referenced by EVERY scenario manifest on this Proxmox, and flush ALL R42-FORWARD firewall rules"
     echo ""
     echo "  scenarios with a manifest:"
     for m in "${manifests[@]}"; do


### PR DESCRIPTION
Closes #205

## Context

The `range42-catalog` repo (`feat/topology-layer-templates` branch) introduces a **topology layer** with reusable network policies. When a scenario is deployed with a network policy, Ansible sets up an `R42-FORWARD` iptables chain on the Proxmox node to enforce inter-subnet isolation. Before this work, `delete-everything` left that chain behind on every teardown — requiring a manual `iptables -X R42-FORWARD` on the hypervisor.

This PR makes `delete-everything` topology-aware: it tears the chain down as part of the nuke sequence, so the Proxmox node is left in a clean state regardless of which network policy was applied.

## Summary

- **R42-FORWARD firewall teardown**: `delete-everything` now SSHes directly to `${RANGE42_INFRASTRUCTURE_CODENAME}-cli` after VM deletion and flushes/removes the R42-FORWARD iptables chain. Non-fatal — a warning is printed if the chain was never deployed or codename is unset.
- **Warning message** updated to mention R42-FORWARD flush.
- Drops the `teardown.yml` dependency — that file is never generated by `r42playbooks new`, so the old approach silently no-oped; direct SSH is reliable.

> **Merge dependency**: should be merged after #201 (revert) and #202 (ssh-reload fix) land in `dev`.

## Test plan

- [ ] Deploy a scenario with a network policy → `range42-context delete-everything` → R42-FORWARD chain is gone on the Proxmox node
- [ ] `range42-context delete-everything` on a scenario without a network policy — teardown returns non-zero (chain absent) but is treated as non-fatal warning
- [ ] `range42-context delete-everything` without `range42-context use` set — prints warning for R42-FORWARD teardown, continues