### PR TITLE
fix(range42-context): delete-everything — non-fatal empty VM list

### DIFF
--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -1139,12 +1139,11 @@ _r42_delete_everything() {
     local _vm_list_json
     _vm_list_json=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
     if [ -z "$_vm_list_json" ]; then
-        _r42_print_fail "proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting nuke"
-        _r42_print_warning "output: ${_vm_list_json[1,200]}"
-        return 1
+        _r42_print_warning "proxmox_vm.list.to.jsons.sh returned no VM data — skipping VM deletion (continuing with firewall + known_hosts cleanup)"
+    else
+        echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+        echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
     fi
-    echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-    echo "$_vm_list_json" | jq -c | grep -E "\"vm_id\":($id_regex)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
     echo ""
     _r42_print_step "cleaning ${#all_ips[@]} known_hosts entries ..."


### PR DESCRIPTION
Closes #209

## Context

When `proxmox_vm.list.to.jsons.sh` returns no data — whether because no VMs are deployed, the Proxmox API is unreachable, or the devkit bug (range42-ansible_roles-debug-devkit#111) is triggered — `delete-everything` aborts immediately with a fatal error.

This means firewall teardown and `known_hosts` cleanup are skipped entirely, even though neither depends on VM state. The deployer is left in a dirty state that requires manual intervention.

This fix is independent of the R42-FORWARD teardown feature (#207): even without a network policy, a hard abort on empty VM list leaves the deployer in a dirty state.

## Summary

- Demotes "no VM data" from a fatal abort to a warning: VM stop/delete is skipped, but firewall teardown and `known_hosts` cleanup always run to completion.

## Test plan

- [ ] `range42-context delete-everything` with no VMs on Proxmox — prints warning, still cleans known_hosts
- [ ] `range42-context delete-everything` when devkit returns empty data (debug-devkit#111 not yet fixed) — degrades gracefully instead of aborting