### PR TITLE
feat: scenario bundles refactor

### DIFF
--- a/range42-context-tui.py
+++ b/range42-context-tui.py
@@ -125,7 +125,7 @@ from textual.screen import ModalScreen
 from textual.theme import Theme
 from textual.widgets import (
     Header, Footer, OptionList, RichLog, Input, ListView, ListItem, Label, Static,
-    Switch, Button,
+    Button,
 )
 from textual.widgets.option_list import Option
 
@@ -746,11 +746,15 @@ class ArgInputScreen(ModalScreen):
         self.dismiss(None)
 
 
-# ── deploy options modal (feature flag toggles) ──────────────────────────────
+# ── deploy options modal (feature flag toggle buttons) ───────────────────────
 class DeployOptionsScreen(ModalScreen):
-    """Modal that renders one Switch per entry of the active scenario's
-    feature_flags.yml. Returns the list of `-e INSTALL_<ID>=YES|NO` args
-    to pass to `range42-context deploy`. Returns None if cancelled."""
+    """Modal that renders one YES/NO toggle Button per entry of the active
+    scenario's feature_flags.yml. Each button shows "YES" in green when the
+    feature will be installed, "NO" in red when it will be skipped. Click
+    flips the state. Returns the list of `-e INSTALL_<ID>=YES|NO` args to
+    pass to `range42-context deploy`. Label and emitted value share the same
+    YES/NO vocabulary so what you click is what gets sent. Returns None if
+    cancelled."""
 
     BINDINGS = [
         Binding("escape", "cancel", "cancel"),
@@ -792,8 +796,10 @@ class DeployOptionsScreen(ModalScreen):
         margin-bottom: 0;
     }
 
-    .deploy-opt-row Switch {
-        margin-right: 1;
+    .deploy-opt-toggle {
+        width: 10;
+        min-width: 10;
+        margin-right: 2;
     }
 
     .deploy-opt-label {
@@ -827,20 +833,23 @@ class DeployOptionsScreen(ModalScreen):
         with Vertical(id="deploy-opts-container"):
             yield Static(f"deploy {self.scenario_name}  -  optional components",
                          id="deploy-opts-title")
-            yield Static("Toggle the components on (install) or off (skip).",
+            yield Static("Click a button to toggle install YES (green) or NO (red).",
                          id="deploy-opts-subtitle")
             with Vertical(id="deploy-opts-list"):
                 for f in self.features:
                     fid = f.get("id", "")
                     label = f.get("label") or fid
+                    initial = bool(self.defaults.get(fid, True))
                     with Horizontal(classes="deploy-opt-row"):
-                        yield Switch(value=bool(self.defaults.get(fid, True)),
-                                     id=f"deploy-opt-{fid}")
+                        yield Button("YES" if initial else "NO",
+                                     id=f"deploy-opt-{fid}",
+                                     variant="success" if initial else "error",
+                                     classes="deploy-opt-toggle")
                         yield Label(label, classes="deploy-opt-label")
             with Horizontal(id="deploy-opts-buttons"):
                 yield Button("Deploy", id="btn-deploy", variant="success")
                 yield Button("Cancel", id="btn-cancel", variant="default")
-            yield Static("Enter=deploy   Esc=cancel   Space/Click=toggle",
+            yield Static("Enter=deploy   Esc=cancel   Click button=toggle",
                          id="deploy-opts-hint")
 
     def on_mount(self) -> None:
@@ -855,18 +864,33 @@ class DeployOptionsScreen(ModalScreen):
         # INSTALL_TAILSCALE convention in the playbooks. The feature `id` in
         # feature_flags.yml is expected to be UPPERCASE (e.g. WAZUH, TAILSCALE),
         # which makes `INSTALL_{fid}` the actual var name the playbook reads.
+        #
+        # Source of truth = the displayed button label (WYSIWYG). Reading the
+        # button's variant or label avoids drift between an internal state dict
+        # and the visible UI - the operator's choice is whatever they see now.
         args = []
         for f in self.features:
             fid = f.get("id", "")
             if not fid:
                 continue
             try:
-                sw = self.query_one(f"#deploy-opt-{fid}", Switch)
-                val = "YES" if bool(sw.value) else "NO"
+                btn = self.query_one(f"#deploy-opt-{fid}", Button)
+                # Variant is the authoritative visual : success = YES, error = NO.
+                val = "YES" if btn.variant == "success" else "NO"
             except Exception:
                 val = "YES" if bool(self.defaults.get(fid, True)) else "NO"
             args.extend(["-e", f"INSTALL_{fid}={val}"])
         return args
+
+    @on(Button.Pressed, ".deploy-opt-toggle")
+    def _on_toggle_btn(self, event: Button.Pressed) -> None:
+        # Flip the visible state of the button. The variant is the source of
+        # truth at _collect_args time so we only need to update label + variant.
+        btn = event.button
+        is_on = btn.variant == "success"
+        new_on = not is_on
+        btn.label = "YES" if new_on else "NO"
+        btn.variant = "success" if new_on else "error"
 
     @on(Button.Pressed, "#btn-deploy")
     def _on_deploy_btn(self, event: Button.Pressed) -> None:

--- a/range42-context-tui.py
+++ b/range42-context-tui.py
@@ -300,7 +300,14 @@ def _parse_workspace_dir(workspace_dir: Path):
 
 
 def _list_workspaces():
-    """Walk CONFIG_BASE_DIR and return [(codename, scenario, dir_name)]."""
+    """Walk CONFIG_BASE_DIR and return [(codename, scenario, dir_name)].
+
+    Filters out workspaces whose linked scenario lacks manifest/scenario_vms.json
+    (matches the conformance predicate used by the wizard's
+    list_deployable_scenarios()). A workspace whose `scenario` symlink is
+    dangling - because the underlying scenario was renamed or dropped from
+    range42-playbooks - is filtered out and must be cleaned up manually.
+    """
     results = []
     try:
         for entry in sorted(CONFIG_BASE_DIR.iterdir()):
@@ -309,9 +316,13 @@ def _list_workspaces():
             if "-" not in entry.name:
                 continue
             parsed = _parse_workspace_dir(entry)
-            if parsed:
-                cn, sc = parsed
-                results.append((cn, sc, entry.name))
+            if not parsed:
+                continue
+            manifest = entry / "scenario" / "manifest" / "scenario_vms.json"
+            if not manifest.is_file():
+                continue
+            cn, sc = parsed
+            results.append((cn, sc, entry.name))
     except (OSError, FileNotFoundError):
         return []
     return results

--- a/range42-init.py
+++ b/range42-init.py
@@ -1250,6 +1250,7 @@ class StepScenario(Step):
             "  Which lab scenario to deploy on this infrastructure.\n\n"
             "  blank_scenario_2_subnets is the minimal lab (4 VMs on 2 subnets) — default.\n"
             "  demo_lab is the full cyber range with admin + student + vulnerable hosts.\n"
+            "  demo_lab_bundles is a POC clone of demo_lab that imports the wazuh stack from bundles/wazuh/ (same VM IDs as demo_lab, do not deploy both on the same Proxmox).\n"
             "  misp_lab deploys a single Ubuntu host pre-provisioned with the Docker baseline, ready to host MISP.\n"
             "  kunai_lab is a 6-VM training scenario (1 trainer + 5 students) with kunai-project repos pre-cloned.\n"
             "  dev_deployer_ui_lab is a 3-VM development lab for the deployer-ui stack.\n\n"

--- a/range42-init.py
+++ b/range42-init.py
@@ -270,8 +270,13 @@ PLAYBOOKS_DIR = SCRIPT_DIR.parent / "range42-playbooks"
 def list_deployable_scenarios():
     """
     Return sorted list of scenario names in range42-playbooks/scenarios/ that
-    have a complete templates/ dir (all 4 required template files present).
-    Scenarios starting with '_' are treated as non-deployable placeholders.
+    look like a complete, deployable scenario :
+      - dir name does not start with '_' (those are non-deployable placeholders)
+      - has manifest/scenario_vms.json (source of truth for VMID / IP / role)
+      - has templates/ dir with all 4 required template files present
+    catalog_try is a regular scenario from this predicate's standpoint (it has
+    both the manifest and the templates) ; it is forced via the --catalog-try
+    CLI flag which bypasses StepScenario.
     """
     scenarios_dir = PLAYBOOKS_DIR / "scenarios"
     if not scenarios_dir.exists():
@@ -280,8 +285,11 @@ def list_deployable_scenarios():
     for d in sorted(scenarios_dir.iterdir()):
         if not d.is_dir() or d.name.startswith("_"):
             continue
+        manifest = d / "manifest" / "scenario_vms.json"
         tmpl = d / "templates"
-        if tmpl.is_dir() and all((tmpl / f).exists() for f in SCENARIO_REQUIRED_FILES):
+        if (manifest.is_file()
+                and tmpl.is_dir()
+                and all((tmpl / f).exists() for f in SCENARIO_REQUIRED_FILES)):
             out.append(d.name)
     return out
 
@@ -1248,13 +1256,10 @@ class StepScenario(Step):
         yield Rule()
         yield Static(
             "  Which lab scenario to deploy on this infrastructure.\n\n"
-            "  blank_scenario_2_subnets is the minimal lab (4 VMs on 2 subnets) — default.\n"
-            "  demo_lab is the full cyber range with admin + student + vulnerable hosts.\n"
-            "  demo_lab_bundles is a POC clone of demo_lab that imports the wazuh stack from bundles/wazuh/ (same VM IDs as demo_lab, do not deploy both on the same Proxmox).\n"
-            "  misp_lab deploys a single Ubuntu host pre-provisioned with the Docker baseline, ready to host MISP.\n"
-            "  kunai_lab is a 6-VM training scenario (1 trainer + 5 students) with kunai-project repos pre-cloned.\n"
-            "  dev_deployer_ui_lab is a 3-VM development lab for the deployer-ui stack.\n\n"
-            "  Pick from the list of deployable scenarios in range42-playbooks.",
+            "  Pick from the auto-discovered list below. Each entry is sourced from\n"
+            "  range42-playbooks/scenarios/<name>/ and must carry\n"
+            "  manifest/scenario_vms.json + a complete templates/ dir to be listed.\n"
+            "  See the scenario's README and manifest for details.",
             classes="muted")
         yield Static("")
 

--- a/roles/deployer.bootstrap/files/range42-context.sh
+++ b/roles/deployer.bootstrap/files/range42-context.sh
@@ -398,7 +398,7 @@ _r42_use() {
         "$RANGE42_SSH_CONFIG_FILE"
     _r42_print_step "commented all active Include lines"
 
-    sed -i "/$RANGE42_SSH_BEGIN_MARK/,/$RANGE42_SSH_END_MARK/ s/^# Include \(.*config_range42-${target}.*\)/Include \1/" \
+    sed -i "/$RANGE42_SSH_BEGIN_MARK/,/$RANGE42_SSH_END_MARK/ s/^# Include \(.*config_range42-${target}\)$/Include \1/" \
         "$RANGE42_SSH_CONFIG_FILE"
     _r42_print_step "uncommented Include for $target"
 


### PR DESCRIPTION
# feat: bundle-driven scenario refactor + optional collaboration apps

Target: `feat-scenario-bundles-refactor` -> `dev` (WAVE_04 integration testing).

> ## !!! MANDATORY after merge !!! - re-init every scenario workspace
>
> This PR changes the scenario **templates** (`ansible-inventory.j2` **and** `ssh-config.j2`):
> new admin VMs (gitea / mattermost / nextcloud / rocketchat) and updated inventory groups.
>
> A workspace created **before** this PR is **stale** - its generated inventory and SSH config
> do NOT contain the new VMs. Deploying against a stale workspace fails with
> `Connection closed by UNKNOWN port 65535` on the new hosts (they match the `r42.admin*` 
> wildcard but have no `Hostname`).
>
> **You MUST regenerate the workspace before deploying:**
>
> ```bash
> # on the deployer, for each scenario context:
> cd ~/range42/range42-playbooks && git pull
> cd ~/range42/range42-catalog   && git pull      # collab-app bundles rsync their compose from catalog
>
> range42-context init                            # REQUIRED: regenerates inventory + ssh-config from the templates
> range42-context show-inventory                  # sanity check: the new admin VMs must be listed
> ```
>
> Applies to **demo_lab**, **blank_scenario_2/4/6**, and any scenario whose VM set changed.

## What this PR does

- **Bundle-driven scenarios.** Every scenario migrated to the canonical shape (`01_templates-bootstrap` + `02_admin_infrastructure` + workload tiers), composing reusable bundles under `bundles/` instead of inline per-scenario plays.
- **Optional collaboration-app bundles.** New reusable  `software.install.{gitea,mattermost,nextcloud,rocketchat}`, wired into `demo_lab` and `blank_scenario_{2,4,6}` as opt-in admin services gated by `INSTALL_<APP>` (default **NO**). The vitrine scenarios (`gitea_lab`, `mattermost_lab`, ...) keep their own flag default YES. 
- **Deployer platform opt-in.** The deployer stack (api-gateway/Kong + api-backend + ui) is now gated behind `INSTALL_DEPLOYER_UI` (default **NO**) in the general scenarios; VM creation +  wazuh enrolment are gated together.
- **kong bundle hardened.** New `software.install.kong` bundle; a systemd drop-in clears dangling unix sockets before nginx start (fixes `EADDRINUSE` on restart after an unclean shutdown). 
- **Fixes.** Added `ssh-config.j2` `Hostname` entries for the collab admin VMs (were unreachable); catalog_try template 9221 IP metadata; wazuh-agent install on Alpine (debug_scenario_a/b); misc.

## Defaults / compatibility

All new admin services default **NO** - a plain deploy brings up the same set as before
(wazuh/misp/deployer per their flags). The new VMs only appear when their `INSTALL_<APP>` flag
is `YES`; otherwise their inventory/ssh-config entries are inert.

## How to test

1. Merge, pull `range42-playbooks` + `range42-catalog` on the deployer, then **run the re-init above**.
2. Full deploy:
   ```bash
   range42-context delete-vms ; ./demo_lab.setup.sh \
     -e INSTALL_WAZUH=YES -e INSTALL_MISP=YES -e INSTALL_GITEA=YES \
     -e INSTALL_MATTERMOST=YES -e INSTALL_NEXTCLOUD=YES -e INSTALL_ROCKETCHAT=YES \
     -e INSTALL_DEPLOYER_UI=YES
   ```
   Or interactively via the TUI: `range42-context --tui` -> select the codename + scenario to use -> choose **deploy** -> an options menu appears listing the available `INSTALL_<flag>` toggles (read from the scenario `feature_flags.yml`, with their defaults); toggle what you want and confirm.
3. Expect `PLAY RECAP` with `failed=0` / `unreachable=0` on the admin VMs (mind Proxmox capacity - this brings up ~6 medium 8 GB VMs plus the deployer trio and CTF boxes).
4. Minimal deploy (all flags omitted / NO) must come up clean - opt-in design.
