### PR TITLE
fix: proxmox.ssh-limits - fix intermittent SSH drops on large scenario deploys

### DIFF
--- a/playbooks/02_configure_proxmox.yml
+++ b/playbooks/02_configure_proxmox.yml
@@ -64,3 +64,38 @@
     - proxmox.init
     - proxmox.jump-user
     - proxmox.api-token
+
+################################################################################
+# Raise the jump host sshd concurrency limit (MaxStartups) so parallel Ansible
+# connections through the ProxyJump are not dropped on large deploys.
+# Runs after root access is established above. The Proxmox is reached as a real
+# ansible host (root over the same key), so the role uses native modules.
+################################################################################
+
+- name: 02 configure proxmox - register the proxmox root ssh target
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    DEPLOYER_CLI_ROOT_DIR: "{{ playbook_dir }}/.."
+    proxmox_root_ssh_key_path: "{{ DEPLOYER_CLI_ROOT_DIR }}/config/{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}/ssh_keys/jump_keys/px.{{ INFRASTRUCTURE_CODENAME }}-{{ INFRASTRUCTURE_SCENARIO }}-ssh_cli.root"
+
+  tasks:
+    - name: register proxmox as an ssh target (root over ssh key)
+      ansible.builtin.add_host:
+        name: r42_proxmox_ssh_target
+        ansible_host: "{{ INFRASTRUCTURE_PROXMOX_ADDRESS }}"
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ proxmox_root_ssh_key_path }}"
+        ansible_python_interpreter: /usr/bin/python3
+
+- name: 02 configure proxmox - raise jump host ssh concurrency limit
+  hosts: r42_proxmox_ssh_target
+  gather_facts: false
+
+  environment:
+    SSH_AUTH_SOCK: "{{ hostvars['localhost']._ssh_auth_sock | default(lookup('env', 'SSH_AUTH_SOCK')) }}"
+
+  roles:
+    - proxmox.ssh-limits

--- a/roles/proxmox.ssh-limits/README.md
+++ b/roles/proxmox.ssh-limits/README.md
@@ -1,0 +1,44 @@
+# proxmox.ssh-limits
+
+Raises the Proxmox (jump host) sshd pre-auth concurrency limit so that parallel
+Ansible connections reaching many VMs through the single `ProxyJump` are not
+dropped by the default `MaxStartups 10:30:100`.
+
+## Why
+
+Scenario deploys open up to `forks` SSH connections at once, all transiting the
+Proxmox jump host. Beyond 10 concurrent pre-auth connections the default sshd
+drops a random fraction, which surfaces as intermittent
+`Connection closed by UNKNOWN port 65535` at `Gathering Facts` (range42 #231).
+
+## What it does
+
+- Writes an isolated drop-in `/etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf`
+  containing only `MaxStartups` (never edits the main `sshd_config`).
+- Reloads sshd so the new limit takes effect.
+
+## Safety
+
+- The rendered drop-in is validated (`sshd -t -f`) **before** it is moved into
+  place: a malformed value never lands on disk.
+- Preflight guards abort if ssh is socket-activated or if `sshd_config` does not
+  `Include` the drop-in directory.
+- Reload only (never restart): the unit `ExecReload=sshd -t` refuses an invalid
+  config and keeps the previous one; existing connections are preserved.
+- On any failure after the write, the drop-in is removed and sshd reloaded back
+  to its previous config.
+- Idempotent: no change and no reload when the drop-in is already correct.
+
+## Variables
+
+| var | default | meaning |
+|---|---|---|
+| `proxmox_ssh_limits_maxstartups` | `100:30:200` | `MaxStartups` value (`start:rate:full`) |
+| `proxmox_ssh_limits_dropin` | `/etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf` | managed drop-in path |
+
+## Manual rollback
+
+```bash
+rm /etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf
+systemctl reload ssh
+```

--- a/roles/proxmox.ssh-limits/defaults/main.yml
+++ b/roles/proxmox.ssh-limits/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# proxmox.ssh-limits - default variables
+#
+# Raises the jump host sshd pre-auth concurrency limit so that parallel Ansible
+# connections reaching many VMs through the single ProxyJump are not dropped by
+# the default MaxStartups (10:30:100).
+
+# MaxStartups value written to the drop-in. Format: start:rate:full.
+# 100:30:200 keeps a wide margin over the Ansible forks setting.
+proxmox_ssh_limits_maxstartups: "100:30:200"
+
+# Drop-in file managed by this role. Isolated: the main sshd_config is never edited.
+proxmox_ssh_limits_dropin: /etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf

--- a/roles/proxmox.ssh-limits/tasks/00_guards.yml
+++ b/roles/proxmox.ssh-limits/tasks/00_guards.yml
@@ -1,0 +1,34 @@
+---
+# Preflight guards - fail early and cleanly on hosts where the drop-in would not
+# take effect, rather than applying blindly.
+
+- name: proxmox.ssh-limits - check whether ssh is socket-activated
+  ansible.builtin.command:
+    argv: [systemctl, is-active, ssh.socket]
+  register: _pxsl_ssh_socket
+  changed_when: false
+  failed_when: false
+
+# Socket-activation would govern concurrency at the systemd socket level and
+# bypass the sshd_config MaxStartups drop-in.
+- name: proxmox.ssh-limits - fail if ssh.socket is active
+  ansible.builtin.fail:
+    msg: >-
+      ssh is socket-activated (ssh.socket is active): the sshd_config MaxStartups
+      drop-in would be bypassed. This host needs a different approach.
+  when: (_pxsl_ssh_socket.stdout | trim) == "active"
+
+- name: proxmox.ssh-limits - check sshd_config includes the drop-in directory
+  ansible.builtin.command:
+    argv: [grep, -qE, '^[[:space:]]*Include.*sshd_config.d', /etc/ssh/sshd_config]
+  register: _pxsl_include
+  changed_when: false
+  failed_when: false
+
+# Without the Include, a file placed in sshd_config.d/ is never loaded.
+- name: proxmox.ssh-limits - fail if the drop-in directory is not included
+  ansible.builtin.fail:
+    msg: >-
+      /etc/ssh/sshd_config does not Include /etc/ssh/sshd_config.d/ ; the drop-in
+      would not be loaded.
+  when: _pxsl_include.rc != 0

--- a/roles/proxmox.ssh-limits/tasks/01_apply.yml
+++ b/roles/proxmox.ssh-limits/tasks/01_apply.yml
@@ -1,0 +1,49 @@
+---
+# Write the MaxStartups drop-in and reload sshd. Safe by construction:
+#   - the rendered file is validated (sshd -t -f) BEFORE it is moved into place,
+#     so a malformed value never lands on disk;
+#   - the running daemon is untouched until an explicit reload;
+#   - reload (never restart) validates via the unit ExecReload=sshd -t and keeps
+#     the previous config if invalid; existing connections are preserved;
+#   - any failure after the write rolls back (removes the drop-in + reloads).
+
+- name: proxmox.ssh-limits - deploy MaxStartups drop-in
+  ansible.builtin.template:
+    src: 60-range42-jump-concurrency.conf.j2
+    dest: "{{ proxmox_ssh_limits_dropin }}"
+    owner: root
+    group: root
+    mode: "0644"
+    backup: false
+    validate: /usr/sbin/sshd -t -f %s
+  register: _pxsl_dropin
+
+- name: proxmox.ssh-limits - validate then reload sshd (rollback on failure)
+  when: _pxsl_dropin.changed
+  block:
+    - name: proxmox.ssh-limits - validate the full merged sshd config
+      ansible.builtin.command:
+        argv: [/usr/sbin/sshd, -t]
+      changed_when: false
+
+    - name: proxmox.ssh-limits - reload sshd (validated by the unit ExecReload)
+      ansible.builtin.systemd:
+        name: ssh
+        state: reloaded
+
+  rescue:
+    - name: proxmox.ssh-limits - ROLLBACK remove drop-in
+      ansible.builtin.file:
+        path: "{{ proxmox_ssh_limits_dropin }}"
+        state: absent
+
+    - name: proxmox.ssh-limits - ROLLBACK reload sshd to restore previous config
+      ansible.builtin.systemd:
+        name: ssh
+        state: reloaded
+
+    - name: proxmox.ssh-limits - fail after rollback
+      ansible.builtin.fail:
+        msg: >-
+          sshd validation or reload failed. The drop-in was removed and sshd was
+          reloaded to its previous config. The daemon kept its prior settings.

--- a/roles/proxmox.ssh-limits/tasks/02_verify.yml
+++ b/roles/proxmox.ssh-limits/tasks/02_verify.yml
@@ -1,0 +1,18 @@
+---
+# Verify the effective MaxStartups on every run (even when the drop-in was already
+# in place) to catch drift or shadowing by another drop-in.
+
+- name: proxmox.ssh-limits - read effective sshd config
+  ansible.builtin.command:
+    argv: [/usr/sbin/sshd, -T]
+  register: _pxsl_effective
+  changed_when: false
+
+- name: proxmox.ssh-limits - assert MaxStartups is effective
+  ansible.builtin.assert:
+    that:
+      - '("maxstartups " ~ proxmox_ssh_limits_maxstartups) in _pxsl_effective.stdout'
+    fail_msg: >-
+      Effective MaxStartups is not {{ proxmox_ssh_limits_maxstartups }} : the
+      drop-in is shadowed or not loaded. Check /etc/ssh/sshd_config.d/.
+    success_msg: "Effective MaxStartups = {{ proxmox_ssh_limits_maxstartups }}"

--- a/roles/proxmox.ssh-limits/tasks/main.yml
+++ b/roles/proxmox.ssh-limits/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# proxmox.ssh-limits
+#
+# Raise the jump host sshd MaxStartups so parallel Ansible connections reaching
+# many VMs through the single ProxyJump are not dropped by the default limit.
+#
+# Runs against the Proxmox host as root (see the calling play in
+# playbooks/02_configure_proxmox.yml). Idempotent. The running sshd is never left
+# on a broken config: the reload validates via the unit ExecReload and never
+# restarts.
+
+- ansible.builtin.import_tasks: 00_guards.yml
+- ansible.builtin.import_tasks: 01_apply.yml
+- ansible.builtin.import_tasks: 02_verify.yml

--- a/roles/proxmox.ssh-limits/templates/60-range42-jump-concurrency.conf.j2
+++ b/roles/proxmox.ssh-limits/templates/60-range42-jump-concurrency.conf.j2
@@ -1,0 +1,4 @@
+# Managed by range42 (role proxmox.ssh-limits). Do not edit by hand.
+# Raise sshd pre-auth concurrency so parallel Ansible connections through this
+# jump host are not dropped (sshd default MaxStartups is 10:30:100).
+MaxStartups {{ proxmox_ssh_limits_maxstartups }}


### PR DESCRIPTION

On large scenario deploys, Ansible fans out many concurrent SSH sessions through the Proxmox jump host at once (one per target VM, during `Gathering Facts`). The jump host sshd hits its default pre-auth concurrency limit (`MaxStartups 10:30:100`) and starts dropping connections before auth, surfacing as intermittent `kex_exchange_identification: Connection closed` / `connection lost` failures that make big deploys flaky.

## What this PR does

Adds the `proxmox.ssh-limits` role (#231) and wires it into `playbooks/02_configure_proxmox.yml` (runs during Proxmox host configuration, after root access is established). The role:

- raises the jump host sshd `MaxStartups` to `100:30:200` via a managed drop-in
  `/etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf`, rendered from a validated template ;
- reloads sshd (not restart) with rollback if the reload fails ;
- preflight guards: fails early if ssh is socket-activated or the drop-in directory is not
  Included by `sshd_config` ;
- verifies the EFFECTIVE value on every run (`sshd -T` assert) to catch drift or a shadowing
  drop-in - so a green run is proof the setting is live ;
- README with the value rationale and manual rollback.

It automates, idempotently and persistently, the manual `MaxStartups` bump that was confirmed to
resolve the drops.

## Defaults / compatibility

- `MaxStartups 100:30:200` (OpenSSH default is `10:30:100`). Idempotent and self-verifying ;   re-running only re-checks the effective value, no churn.
- Scope is the Proxmox HOST sshd only - no change to any scenario or VM.

## How to test

-  From a clean baseline on the Proxmox (`sshd -T | grep -i maxstartups` = `10:30:100`) ; run a range42-context init ; setup a new scenario or overwrite existing one.
-  Expect the drop-in task `changed` and `proxmox.ssh-limits - assert MaxStartups is effective` ok.

   On the Proxmox:
   ```bash
   sshd -T | grep -i maxstartups        # 100:30:200
   cat /etc/ssh/sshd_config.d/60-range42-jump-concurrency.conf
   ```
- Real symptom: run a large deploy (e.g. `blank_scenario_6_subnets`) and confirm no    `Connection closed / connection lost` during `Gathering Facts`.

- Rollback if needed: remove the drop-in and `systemctl reload ssh` (back to the default).
